### PR TITLE
Link status notification enabled by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/.build*/*
 **/bin/*
 *.o
+.*.swp
 *.xe
 *.vcd
 *.s

--- a/lib_ethernet/src/client_state.xc
+++ b/lib_ethernet/src/client_state.xc
@@ -7,7 +7,7 @@ void init_rx_client_state(rx_client_state_t client_state[n], unsigned n)
     client_state[i].dropped_pkt_cnt = 0;
     client_state[i].rd_index = 0;
     client_state[i].wr_index = 0;
-    client_state[i].status_update_state = STATUS_UPDATE_IGNORING;
+    client_state[i].status_update_state = STATUS_UPDATE_WAITING;
     client_state[i].num_etype_filters = 0;
     client_state[i].strip_vlan_tags = 0;
   }


### PR DESCRIPTION
Fix TSN app notes that expect old behaviour where link status notifications were always enabled. Enable/disable calls added in a5d7221dbd76faa7526083da2eef06e14609b6fb with disabled by default.