### PR TITLE
Update AN00199 to xCORE-200 sliceKIT and Gigabit slice with Microchip KSZ9031RNX PHY

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Ethernet MAC library change log
 ===============================
 
+3.3.1
+-----
+
+  * ADDED: Function to write SMI extended MMD registers that some PHYs use
+  * ADDED: Function to reset PHY by writing bit 15 of SMI register 0
+
 3.3.0
 -----
 

--- a/examples/AN00199_gigabit_ethernet_demo/Makefile
+++ b/examples/AN00199_gigabit_ethernet_demo/Makefile
@@ -2,7 +2,7 @@
 # compiled for. It either refers to an XN file in the source directories
 # or a valid argument for the --target option when compiling.
 
-TARGET = XCORE-200-EXPLORER
+TARGET = SLICEKIT-ETH1
 
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to 

--- a/examples/AN00199_gigabit_ethernet_demo/README.rst
+++ b/examples/AN00199_gigabit_ethernet_demo/README.rst
@@ -1,7 +1,7 @@
 XMOS Gigabit Ethernet application note
 ======================================
 
-.. version:: 1.0.2
+.. version:: 1.0.2b
 
 Summary
 -------
@@ -33,9 +33,11 @@ Required hardware
 
 This application note is designed to run on an XMOS xCORE-200 series device.
 The example code provided with the application has been implemented
-and tested on the xCORE-200 Explorer development kit.
-There is no dependancy on this board - it can be modified to run on
-any xCORE-200 series device with gigabit Ethernet capability.
+and tested on the X200 sliceKIT 1V0 (XK-SK-X200-ST) core board together
+with Gigabit Ethernet sliceCARD 1V0 (XA-SK-GBE) with Microchip KSZ9031RNX
+PHY. There is no dependancy on this board - it can be modified to run on
+any xCORE-200 series device with gigabit Ethernet capability and the same
+Ethernet PHY.
 
 Prerequisites
 ..............

--- a/examples/AN00199_gigabit_ethernet_demo/SLICEKIT-ETH1.xn
+++ b/examples/AN00199_gigabit_ethernet_demo/SLICEKIT-ETH1.xn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<Network xmlns="http://www.xmos.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.xmos.com http://www.xmos.com">
+  <Type>Board</Type>
+  <Name>sliceKIT Core Board (X200)</Name>
+  <Declarations>
+    <Declaration>tileref tile[2]</Declaration>
+    <Declaration>tileref usb_tile</Declaration>
+  </Declarations>
+  <Packages>
+    <Package id="0" Type="XS2-EnA-512-FB236">
+      <Nodes>
+        <Node Id="0" InPackageId="0" Type="XS2-L16A-512" OscillatorSrc="1" SystemFrequency="500MHz">
+          <Boot>
+            <Source Location="bootFlash"/>
+          </Boot>
+          <Tile Number="0" Reference="tile[0]">
+            <Port Location="XS1_PORT_1B" Name="PORT_SQI_CS"/>
+            <Port Location="XS1_PORT_1C" Name="PORT_SQI_SCLK"/>
+            <Port Location="XS1_PORT_4B" Name="PORT_SQI_SIO"/>
+          </Tile>
+          <Tile Number="1" Reference="tile[1]">
+            <Port Location="XS1_PORT_1C" Name="PORT_SMI_MDIO"/>
+            <Port Location="XS1_PORT_1D" Name="PORT_SMI_MDC"/>
+            <Port Location="XS1_PORT_8D" Name="PORT_SMI_INT"/>
+            <Port Location="XS1_PORT_1L" Name="PORT_ETH_RST"/>
+	  </Tile>
+        </Node>
+        <Node Id="1" InPackageId="1" Type="periph:XS1-SU" Reference="usb_tile" Oscillator="24MHz">
+        </Node>		
+      </Nodes>
+      <Links>
+        <Link Encoding="5wire">
+          <LinkEndpoint NodeId="0" Link="8" Delays="52clk,52clk"/>
+          <LinkEndpoint NodeId="1" Link="XL0" Delays="1clk,1clk"/>
+        </Link>
+      </Links> 
+   </Package>
+  </Packages>
+  <Nodes>
+    <Node Id="2" Type="device:" RoutingId="0x8000">
+      <Service Id="0" Proto="xscope_host_data(chanend c);">
+        <Chanend Identifier="c" end="3"/>
+      </Service>
+    </Node>
+  </Nodes>
+  <Links>
+    <Link Encoding="2wire" Delays="5clk" Flags="XSCOPE">
+      <LinkEndpoint NodeId="0" Link="XL1"/>
+      <LinkEndpoint NodeId="2" Chanend="1"/>
+    </Link>
+  </Links>
+  <ExternalDevices>
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="IS25LQ032B">
+      <Attribute Name="PORT_SQI_CS"      Value="PORT_SQI_CS"/>
+      <Attribute Name="PORT_SQI_SCLK"    Value="PORT_SQI_SCLK"/>
+      <Attribute Name="PORT_SQI_SIO"     Value="PORT_SQI_SIO"/>
+    </Device>
+  </ExternalDevices>
+  <JTAGChain>
+    <JTAGDevice NodeId="0"/>
+  </JTAGChain>
+</Network>

--- a/examples/AN00199_gigabit_ethernet_demo/doc/rst/AN00199.rst
+++ b/examples/AN00199_gigabit_ethernet_demo/doc/rst/AN00199.rst
@@ -199,12 +199,18 @@ functions implement the ICMP protocol.
 Demo Hardware Setup
 --------------------
 
+ * Insert Gigabit Ethernet sliceCARD into slot pair of tile 0 or 1,
+   as indicated in source code below
  * To run the demo, connect the PC to the XTAG USB debug adapter to
-   xCORE-200 explorer XSYS connector
+   X200 sliceKIT XSYS connector
  * Connect the XTAG to the host PC using a USB cable
  * Connect the ethernet jack to the host PC or to the network switch
-   using an ethernet cable.
+   using an ethernet cable
 
+.. literalinclude:: main.xc
+   :start-on: rgmii_ports_t
+   :end-on: p_eth_reset
+   
 |newpage|
 
 Launching the demo device
@@ -221,7 +227,7 @@ Alter this value to an IP address that works on your network.
 
 You can now build the project which will generate the binary file required to run the demo application.
 Once the application has been built you need to download the
-application code onto the xCORE-200 explorer.
+application code onto the X200 sliceKIT.
 Here you use the tools to load the application over JTAG onto the xCORE device.
 
  * Select **Run Configuration**.

--- a/examples/AN00199_gigabit_ethernet_demo/src/main.xc
+++ b/examples/AN00199_gigabit_ethernet_demo/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
 #include <xs1.h>
 #include <platform.h>
 #include "otp_board_info.h"
@@ -10,11 +10,12 @@
 // These ports are for accessing the OTP memory
 otp_ports_t otp_ports = on tile[0]: OTP_PORTS_INITIALIZER;
 
+// Tile number used in app note text
 rgmii_ports_t rgmii_ports = on tile[1]: RGMII_PORTS_INITIALIZER;
 
-port p_smi_mdio   = on tile[1]: XS1_PORT_1C;
-port p_smi_mdc    = on tile[1]: XS1_PORT_1D;
-port p_eth_reset  = on tile[1]: XS1_PORT_1N;
+port p_smi_mdio   = PORT_SMI_MDIO;
+port p_smi_mdc    = PORT_SMI_MDC;
+port p_eth_reset  = PORT_ETH_RST;
 
 static unsigned char ip_address[4] = {192, 168, 1, 178};
 
@@ -32,14 +33,46 @@ enum cfg_clients {
   NUM_CFG_CLIENTS
 };
 
+#define KSZ9031RNX_MMD_PAD_SKEW_DEV_ADDR 2
+#define KSZ9031RNX_MMD_PAD_SKEW_CONTROL_PADS 4
+#define KSZ9031RNX_MMD_PAD_SKEW_RX_DATA_PADS 5
+#define KSZ9031RNX_MMD_PAD_SKEW_TX_DATA_PADS 6
+#define KSZ9031RNX_MMD_PAD_SKEW_CLOCK_PADS 8
+
+#define PAD_SKEW_RXDV 7
+#define PAD_SKEW_RXD 7
+#define PAD_SKEW_RXC 15
+#define PAD_SKEW_TXEN 7
+#define PAD_SKEW_TXD 7
+#define PAD_SKEW_TXC 15
+
+static void configure_phy_delays(client interface smi_if smi, int phy_address)
+{
+  smi_mmd_write(smi, phy_address, KSZ9031RNX_MMD_PAD_SKEW_DEV_ADDR,
+                KSZ9031RNX_MMD_PAD_SKEW_CONTROL_PADS,
+                (PAD_SKEW_RXDV << 4) | PAD_SKEW_TXEN);
+
+  smi_mmd_write(smi, phy_address, KSZ9031RNX_MMD_PAD_SKEW_DEV_ADDR,
+                KSZ9031RNX_MMD_PAD_SKEW_RX_DATA_PADS,
+                (PAD_SKEW_RXD << 12) | (PAD_SKEW_RXD << 8) | (PAD_SKEW_RXD << 4) | PAD_SKEW_RXD);
+
+  smi_mmd_write(smi, phy_address, KSZ9031RNX_MMD_PAD_SKEW_DEV_ADDR,
+                KSZ9031RNX_MMD_PAD_SKEW_TX_DATA_PADS,
+                (PAD_SKEW_TXD << 12) | (PAD_SKEW_TXD << 8) | (PAD_SKEW_TXD << 4) | PAD_SKEW_TXD);
+
+  smi_mmd_write(smi, phy_address, KSZ9031RNX_MMD_PAD_SKEW_DEV_ADDR,
+                KSZ9031RNX_MMD_PAD_SKEW_CLOCK_PADS,
+                (PAD_SKEW_TXC << 5) | (PAD_SKEW_RXC));
+}
+
 [[combinable]]
-void ar8035_phy_driver(client interface smi_if smi,
-                client interface ethernet_cfg_if eth) {
+void ksz9031_phy_driver(client interface smi_if smi,
+                        client interface ethernet_cfg_if eth) {
   ethernet_link_state_t link_state = ETHERNET_LINK_DOWN;
   ethernet_speed_t link_speed = LINK_1000_MBPS_FULL_DUPLEX;
   const int phy_reset_delay_ms = 1;
   const int link_poll_period_ms = 1000;
-  const int phy_address = 0x4;
+  const int phy_address = 3;
   timer tmr;
   int t;
   tmr :> t;
@@ -48,19 +81,23 @@ void ar8035_phy_driver(client interface smi_if smi,
   p_eth_reset <: 1;
 
   while (smi_phy_is_powered_down(smi, phy_address));
+
+  configure_phy_delays(smi, phy_address);
+
   smi_configure(smi, phy_address, LINK_1000_MBPS_FULL_DUPLEX, SMI_ENABLE_AUTONEG);
 
   while (1) {
     select {
     case tmr when timerafter(t) :> t:
       ethernet_link_state_t new_state = smi_get_link_state(smi, phy_address);
-      // Read AR8035 status register bits 15:14 to get the current link speed
+      // Poll status register bits 15:14 to get the current link speed
       if (new_state == ETHERNET_LINK_UP) {
         link_speed = (ethernet_speed_t)(smi.read_reg(phy_address, 0x11) >> 14) & 3;
       }
       if (new_state != link_state) {
         link_state = new_state;
         eth.set_link_state(0, new_state, link_speed);
+        debug_printf("Link state %d\n", new_state);
       }
       t += link_poll_period_ms * XS1_TIMER_KHZ;
       break;
@@ -84,7 +121,7 @@ int main()
                                    rgmii_ports, 
                                    ETHERNET_DISABLE_SHAPER);
     on tile[1].core[0]: rgmii_ethernet_mac_config(i_cfg, NUM_CFG_CLIENTS, c_rgmii_cfg);
-    on tile[1].core[0]: ar8035_phy_driver(i_smi, i_cfg[CFG_TO_PHY_DRIVER]);
+    on tile[1].core[0]: ksz9031_phy_driver(i_smi, i_cfg[CFG_TO_PHY_DRIVER]);
   
     on tile[1]: smi(i_smi, p_smi_mdio, p_smi_mdc);
 

--- a/examples/AN00199_gigabit_ethernet_demo/src/main.xc
+++ b/examples/AN00199_gigabit_ethernet_demo/src/main.xc
@@ -70,7 +70,7 @@ void ksz9031_phy_driver(client interface smi_if smi,
                         client interface ethernet_cfg_if eth) {
   ethernet_link_state_t link_state = ETHERNET_LINK_DOWN;
   ethernet_speed_t link_speed = LINK_1000_MBPS_FULL_DUPLEX;
-  const int phy_reset_delay_ms = 1;
+  const int phy_reset_delay_ms = 10;
   const int link_poll_period_ms = 1000;
   const int phy_address = 3;
   timer tmr;
@@ -79,8 +79,11 @@ void ksz9031_phy_driver(client interface smi_if smi,
   p_eth_reset <: 0;
   delay_milliseconds(phy_reset_delay_ms);
   p_eth_reset <: 1;
+  delay_microseconds(100);
 
   while (smi_phy_is_powered_down(smi, phy_address));
+
+  smi_phy_reset(smi, phy_address);
 
   configure_phy_delays(smi, phy_address);
 

--- a/lib_ethernet/api/smi.h
+++ b/lib_ethernet/api/smi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, XMOS Ltd, All rights reserved
+// Copyright (c) 2014-2017, XMOS Ltd, All rights reserved
 #ifndef _smi_h_
 #define _smi_h_
 #include <stdint.h>
@@ -121,6 +121,13 @@ void smi_set_loopback_mode(client smi_if smi, uint8_t phy_address, int enable);
  */
 unsigned smi_get_id(client smi_if smi, uint8_t phy_address);
 
+/** Reset PHY by writing bit 15 of the Control register
+ *
+ *  \param smi          An interface connection to the SMI component
+ *  \param phy_address  The 5-bit SMI address of the PHY
+ */
+void smi_phy_reset(client smi_if smi, uint8_t phy_address);
+
 /** Function to retrieve the power down status of the PHY.
  *
  *  \param smi          An interface connection to the SMI component
@@ -128,6 +135,24 @@ unsigned smi_get_id(client smi_if smi, uint8_t phy_address);
  *  \returns            ``1`` if the PHY is powered down, ``0`` otherwise
  */
 unsigned smi_phy_is_powered_down(client smi_if smi, uint8_t phy_address);
+
+/** SMI MMD write
+ *
+ *  Some PHYs expose additional registers to basic SMI through MMD,
+ *  MDIO Manageable Device, annex 22D.
+ *
+ *  There is a suggested set of MMD registers in clause 45, but vendors
+ *  don't necessarily follow it. It's best to refer to your PHY datasheet.
+ *
+ *  \param smi          An interface connection to the SMI component
+ *  \param phy_address  The 5-bit SMI address of the PHY
+ *  \param mmd_dev      16-bit MMD device address
+ *  \param mmd_reg      16-bit MMD register number
+ *  \param value        16-bit value to write
+ */
+void smi_mmd_write(client smi_if smi, uint8_t phy_address,
+                   uint16_t mmd_dev, uint16_t mmd_reg,
+		   uint16_t value);
 
 /** Function to retrieve the link up/down status.
  *

--- a/lib_ethernet/module_build_info
+++ b/lib_ethernet/module_build_info
@@ -21,4 +21,4 @@ XCC_FLAGS_mii.xc = $(MODULE_XCC_FLAGS) -Wno-cast-align
 XCC_FLAGS_mii_ethernet_mac.xc = $(MODULE_XCC_FLAGS) -Wno-cast-align
 XCC_FLAGS_ethernet.xc = $(MODULE_XCC_FLAGS) -Wno-cast-align
 
-VERSION = 3.3.0
+VERSION = 3.3.1

--- a/tests/test_time_rx_tx/src/main.xc
+++ b/tests/test_time_rx_tx/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016, XMOS Ltd, All rights reserved
+// Copyright (c) 2014-2017, XMOS Ltd, All rights reserved
 #include <xs1.h>
 #include <platform.h>
 #include "ethernet.h"


### PR DESCRIPTION
I'm not proposing the app note be changed from eXplorerKIT to sliceKIT. eXplorerKIT is cheaper and has PHY on it rather than need a separate slice. It's more a proposal to split the app note in two app notes or make an app note that has two different targets.