### PR TITLE
Re-apply original copyright years

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2021 XMOS LIMITED.
+# Copyright 2020-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 


### PR DESCRIPTION
The original copyright years must be re-applied now that the infr_apps source checking script has been fixed.