### PR TITLE
Feature/remove unsafe rmii

### DIFF
--- a/doc/rst/lib_ethernet.rst
+++ b/doc/rst/lib_ethernet.rst
@@ -474,8 +474,8 @@ Similarly the RMII real-time MAC may be instantiated::
         rmii_ethernet_rt_mac(i_cfg, 1, i_rx_lp, 1, i_tx_lp, 1,
                             c_rx_hp, c_tx_hp,
                             p_eth_clk,
-                            &p_eth_rxd, p_eth_rxdv,
-                            p_eth_txen, &p_eth_txd,
+                            p_eth_rxd, p_eth_rxdv,
+                            p_eth_txen, p_eth_txd,
                             eth_rxclk, eth_txclk,
                             4000, 4000, ETHERNET_ENABLE_SHAPER);
        application(i_cfg[0], i_rx_lp[0], i_tx_lp[0], c_rx_hp, c_tx_hp);

--- a/lib_ethernet/api/ethernet.h
+++ b/lib_ethernet/api/ethernet.h
@@ -613,7 +613,7 @@ typedef enum rmii_data_4b_pin_assignment_t{
 /** Structure representing a four bit port used for RMII data transmission or reception */
 typedef struct rmii_data_4b_t
 {
-    port data;                              /**< Four bit data port */
+    unsigned data;                          /**< Four bit data port */
     rmii_data_4b_pin_assignment_t pins_used;/**< Which two bits of the data port to use.
                                                  Unused Rx pins are ignored and unused
                                                  Tx pins are driven low. */
@@ -622,8 +622,8 @@ typedef struct rmii_data_4b_t
 /** Structure type representing a pair of one bit ports used for RMII data transmission or reception. */
 typedef struct rmii_data_1b_t
 {
-    port data_0;                            /**< One bit data port for lower data line. */
-    port data_1;                            /**< One bit data port for upper data line. */
+    unsigned data_0;                        /**< One bit data port for lower data line. */
+    unsigned data_1;                        /**< One bit data port for upper data line. */
 } rmii_data_1b_t;
 
 
@@ -677,8 +677,8 @@ void rmii_ethernet_rt_mac(SERVER_INTERFACE(ethernet_cfg_if, i_cfg[n_cfg]), stati
                           SERVER_INTERFACE(ethernet_tx_if, i_tx_lp[n_tx_lp]), static_const_unsigned_t n_tx_lp,
                           nullable_streaming_chanend_t c_rx_hp,
                           nullable_streaming_chanend_t c_tx_hp,
-                          in_port_t p_clk, rmii_data_port_t * unsafe p_rxd, in_port_t p_rxdv,
-                          out_port_t p_txen, rmii_data_port_t * unsafe p_txd,
+                          in_port_t p_clk, rmii_data_port_t p_rxd, in_port_t p_rxdv,
+                          out_port_t p_txen, rmii_data_port_t p_txd,
                           clock rxclk,
                           clock txclk,
                           static_const_unsigned_t rx_bufsize_words,

--- a/lib_ethernet/src/rmii_ethernet_rt_mac.xc
+++ b/lib_ethernet/src/rmii_ethernet_rt_mac.xc
@@ -43,8 +43,8 @@ void rmii_ethernet_rt_mac(SERVER_INTERFACE(ethernet_cfg_if, i_cfg[n_cfg]), stati
                           nullable_streaming_chanend_t c_rx_hp,
                           nullable_streaming_chanend_t c_tx_hp,
                           in_port_t p_clk,
-                          rmii_data_port_t * unsafe p_rxd, in_port_t p_rxdv,
-                          out_port_t p_txen, rmii_data_port_t * unsafe p_txd,
+                          rmii_data_port_t p_rxd, in_port_t p_rxdv,
+                          out_port_t p_txen, rmii_data_port_t p_txd,
                           clock rxclk,
                           clock txclk,
                           static_const_unsigned_t rx_bufsize_words,
@@ -102,18 +102,18 @@ void rmii_ethernet_rt_mac(SERVER_INTERFACE(ethernet_cfg_if, i_cfg[n_cfg]), stati
     in buffered port:32 * unsafe rx_data_1 = NULL;
 
     // Extract width and optionally which 4b pins to use
-    unsigned rx_port_width = ((unsigned)(p_rxd->rmii_data_1b.data_0) >> 16) & 0xff;
-    rmii_data_4b_pin_assignment_t rx_port_4b_pins = (rmii_data_4b_pin_assignment_t)(p_rxd->rmii_data_1b.data_1);
+    unsigned rx_port_width = ((p_rxd.rmii_data_1b.data_0) >> 16) & 0xff;
+    rmii_data_4b_pin_assignment_t rx_port_4b_pins = (p_rxd.rmii_data_1b.data_1);
 
     // Extract pointers to ports with correct port qualifiers and setup data pins
     switch(rx_port_width){
       case 4:
-        rx_data_0 = enable_buffered_in_port((unsigned*)(&p_rxd->rmii_data_1b.data_0), 32);
+        rx_data_0 = enable_buffered_in_port((&p_rxd.rmii_data_1b.data_0), 32);
         rmii_master_init_rx_4b(p_clk, rx_data_0, p_rxdv, rxclk);
         break;
       case 1:
-        rx_data_0 = enable_buffered_in_port((unsigned*)&p_rxd->rmii_data_1b.data_0, 32);
-        rx_data_1 = enable_buffered_in_port((unsigned*)&p_rxd->rmii_data_1b.data_1, 32);
+        rx_data_0 = enable_buffered_in_port(&p_rxd.rmii_data_1b.data_0, 32);
+        rx_data_1 = enable_buffered_in_port(&p_rxd.rmii_data_1b.data_1, 32);
         rmii_master_init_rx_1b(p_clk, rx_data_0, rx_data_1, p_rxdv, rxclk);
         break;
       default:
@@ -125,17 +125,17 @@ void rmii_ethernet_rt_mac(SERVER_INTERFACE(ethernet_cfg_if, i_cfg[n_cfg]), stati
     out buffered port:32 * unsafe tx_data_0 = NULL;
     out buffered port:32 * unsafe tx_data_1 = NULL;
 
-    unsigned tx_port_width = ((unsigned)(p_txd->rmii_data_1b.data_0) >> 16) & 0xff;
-    rmii_data_4b_pin_assignment_t tx_port_4b_pins = (rmii_data_4b_pin_assignment_t)(p_txd->rmii_data_1b.data_1);
+    unsigned tx_port_width = ((p_txd.rmii_data_1b.data_0) >> 16) & 0xff;
+    rmii_data_4b_pin_assignment_t tx_port_4b_pins = (p_txd.rmii_data_1b.data_1);
 
     switch(tx_port_width){
       case 4:
-        tx_data_0 = enable_buffered_out_port((unsigned*)(&p_txd->rmii_data_1b.data_0), 32);
+        tx_data_0 = enable_buffered_out_port((&p_txd.rmii_data_1b.data_0), 32);
         rmii_master_init_tx_4b(p_clk, tx_data_0, p_txen, txclk);
         break;
       case 1:
-        tx_data_0 = enable_buffered_out_port((unsigned*)&p_txd->rmii_data_1b.data_0, 32);
-        tx_data_1 = enable_buffered_out_port((unsigned*)&p_txd->rmii_data_1b.data_1, 32);
+        tx_data_0 = enable_buffered_out_port(&p_txd.rmii_data_1b.data_0, 32);
+        tx_data_1 = enable_buffered_out_port(&p_txd.rmii_data_1b.data_1, 32);
         rmii_master_init_tx_1b(p_clk, tx_data_0, tx_data_1, p_txen, txclk);
         break;
       default:

--- a/tests/include/ports_rmii.h
+++ b/tests/include/ports_rmii.h
@@ -27,13 +27,13 @@
 #endif
 
 #if RX_USE_LOWER_2B
-rmii_data_port_t p_eth_rxd = {{on tile[0]:XS1_PORT_4A, USE_LOWER_2B}};
+rmii_data_port_t p_eth_rxd = {{XS1_PORT_4A, USE_LOWER_2B}};
 #elif RX_USE_UPPER_2B
-rmii_data_port_t p_eth_rxd = {{on tile[0]:XS1_PORT_4A, USE_UPPER_2B}};
+rmii_data_port_t p_eth_rxd = {{XS1_PORT_4A, USE_UPPER_2B}};
 #endif
 
 #elif RX_WIDTH == 1
-rmii_data_port_t p_eth_rxd = {{on tile[0]:XS1_PORT_1A, XS1_PORT_1B}};
+rmii_data_port_t p_eth_rxd = {{XS1_PORT_1A, XS1_PORT_1B}};
 #else
 #error invalid RX_WIDTH
 #endif
@@ -49,13 +49,13 @@ rmii_data_port_t p_eth_rxd = {{on tile[0]:XS1_PORT_1A, XS1_PORT_1B}};
 #endif
 
 #if TX_USE_LOWER_2B
-  rmii_data_port_t p_eth_txd = {{on tile[0]:XS1_PORT_4B, USE_LOWER_2B}};
+  rmii_data_port_t p_eth_txd = {{XS1_PORT_4B, USE_LOWER_2B}};
 #elif TX_USE_UPPER_2B
-  rmii_data_port_t p_eth_txd = {{on tile[0]:XS1_PORT_4B, USE_UPPER_2B}};
+  rmii_data_port_t p_eth_txd = {{XS1_PORT_4B, USE_UPPER_2B}};
 #endif
 
 #elif TX_WIDTH == 1
-rmii_data_port_t p_eth_txd = {{on tile[0]:XS1_PORT_1C, XS1_PORT_1D}};
+rmii_data_port_t p_eth_txd = {{XS1_PORT_1C, XS1_PORT_1D}};
 #else
 #error invalid TX_WIDTH
 #endif

--- a/tests/test_appdata/src/main.xc
+++ b/tests/test_appdata/src/main.xc
@@ -125,15 +125,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
                                 i_rx_lp, NUM_RX_LP_IF,
                                 i_tx_lp, NUM_TX_LP_IF,
                                 c_rx_hp, null,
                                 p_eth_clk,
-                                &p_eth_rxd, p_eth_rxdv,
-                                p_eth_txen, &p_eth_txd,
+                                p_eth_rxd, p_eth_rxdv,
+                                p_eth_txen, p_eth_txd,
                                 eth_rxclk, eth_txclk,
-                                4000, 4000, ETHERNET_DISABLE_SHAPER);}
+                                4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
     on tile[0]: filler(0x77);
 

--- a/tests/test_avb_traffic/src/main.xc
+++ b/tests/test_avb_traffic/src/main.xc
@@ -199,15 +199,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
                                 i_rx_lp, NUM_RX_LP_IF,
                                 i_tx_lp, NUM_TX_LP_IF,
                                 c_rx_hp, null,
                                 p_eth_clk,
-                                &p_eth_rxd, p_eth_rxdv,
-                                p_eth_txen, &p_eth_txd,
+                                p_eth_rxd, p_eth_rxdv,
+                                p_eth_txen, p_eth_txd,
                                 eth_rxclk, eth_txclk,
-                                4000, 4000, ETHERNET_DISABLE_SHAPER);}
+                                4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
     on tile[0]: filler(0x1111);
 

--- a/tests/test_etype_filter/src/main.xc
+++ b/tests/test_etype_filter/src/main.xc
@@ -102,15 +102,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
                                 i_rx_lp, NUM_RX_LP_IF,
                                 i_tx_lp, NUM_TX_LP_IF,
                                 null, null,
                                 p_eth_clk,
-                                &p_eth_rxd, p_eth_rxdv,
-                                p_eth_txen, &p_eth_txd,
+                                p_eth_rxd, p_eth_rxdv,
+                                p_eth_txen, p_eth_txd,
                                 eth_rxclk, eth_txclk,
-                                4000, 4000, ETHERNET_DISABLE_SHAPER);}
+                                4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
     on tile[0]: filler(0x77);
 

--- a/tests/test_link_status/src/main.xc
+++ b/tests/test_link_status/src/main.xc
@@ -120,15 +120,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
                                 i_rx_lp, NUM_RX_LP_IF,
                                 i_tx_lp, NUM_TX_LP_IF,
                                 null, null,
                                 p_eth_clk,
-                                &p_eth_rxd, p_eth_rxdv,
-                                p_eth_txen, &p_eth_txd,
+                                p_eth_rxd, p_eth_rxdv,
+                                p_eth_txen, p_eth_txd,
                                 eth_rxclk, eth_txclk,
-                                4000, 4000, ETHERNET_DISABLE_SHAPER);}
+                                4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
 
     on tile[0]: filler(0x1111);

--- a/tests/test_rx/src/main.xc
+++ b/tests/test_rx/src/main.xc
@@ -213,15 +213,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
                                           i_rx_lp, NUM_RX_LP_IF,
                                           i_tx_lp, NUM_TX_LP_IF,
                                           c_rx_hp, c_tx_hp,
                                           p_eth_clk,
-                                          &p_eth_rxd, p_eth_rxdv,
-                                          p_eth_txen, &p_eth_txd,
+                                          p_eth_rxd, p_eth_rxdv,
+                                          p_eth_txen, p_eth_txd,
                                           eth_rxclk, eth_txclk,
-                                          4000, 4000, ETHERNET_DISABLE_SHAPER);}
+                                          4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
 
     on tile[0]: filler(0x1111);

--- a/tests/test_rx_backpressure/src/main.xc
+++ b/tests/test_rx_backpressure/src/main.xc
@@ -205,15 +205,15 @@ int main()
                                     eth_rxclk, eth_txclk,
                                     4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-    on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
-                                        i_rx_lp, NUM_RX_LP_IF,
-                                        i_tx_lp, NUM_TX_LP_IF,
-                                        c_rx_hp, c_tx_hp,
-                                        p_eth_clk,
-                                        &p_eth_rxd, p_eth_rxdv,
-                                        p_eth_txen, &p_eth_txd,
-                                        eth_rxclk, eth_txclk,
-                                        4000, 4000, ETHERNET_DISABLE_SHAPER);}
+    on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+                                    i_rx_lp, NUM_RX_LP_IF,
+                                    i_tx_lp, NUM_TX_LP_IF,
+                                    c_rx_hp, c_tx_hp,
+                                    p_eth_clk,
+                                    p_eth_rxd, p_eth_rxdv,
+                                    p_eth_txen, p_eth_txd,
+                                    eth_rxclk, eth_txclk,
+                                    4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
 
     on tile[0]: filler(0x1111);

--- a/tests/test_rx_queues/src/main.xc
+++ b/tests/test_rx_queues/src/main.xc
@@ -188,15 +188,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
-                              i_rx_lp, NUM_RX_LP_IF,
-                              i_tx_lp, NUM_TX_LP_IF,
-                              c_rx_hp, null,
-                              p_eth_clk,
-                              &p_eth_rxd, p_eth_rxdv,
-                              p_eth_txen, &p_eth_txd,
-                              eth_rxclk, eth_txclk,
-                              4000, 4000, ETHERNET_DISABLE_SHAPER);}
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+                                      i_rx_lp, NUM_RX_LP_IF,
+                                      i_tx_lp, NUM_TX_LP_IF,
+                                      c_rx_hp, null,
+                                      p_eth_clk,
+                                      p_eth_rxd, p_eth_rxdv,
+                                      p_eth_txen, p_eth_txd,
+                                      eth_rxclk, eth_txclk,
+                                      4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
 
     #endif // RGMII

--- a/tests/test_shaper/src/main.xc
+++ b/tests/test_shaper/src/main.xc
@@ -200,15 +200,15 @@ int main()
                                     eth_rxclk, eth_txclk,
                                     4000, 4000, ETHERNET_ENABLE_SHAPER);
   #elif RMII
-    on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+    on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
                             i_rx_lp, NUM_RX_LP_IF,
                             i_tx_lp, NUM_TX_LP_IF,
                             null, c_tx_hp,
                             p_eth_clk,
-                            &p_eth_rxd, p_eth_rxdv,
-                            p_eth_txen, &p_eth_txd,
+                            p_eth_rxd, p_eth_rxdv,
+                            p_eth_txen, p_eth_txd,
                             eth_rxclk, eth_txclk,
-                            4000, 4000, ETHERNET_ENABLE_SHAPER);}
+                            4000, 4000, ETHERNET_ENABLE_SHAPER);
   #endif
     on tile[0]: filler(0x1111);
     on tile[0]: filler(0x3333);

--- a/tests/test_time_rx/src/main_mii_rt.h
+++ b/tests/test_time_rx/src/main_mii_rt.h
@@ -31,15 +31,15 @@ int main()
                                     eth_rxclk, eth_txclk,
                                     4000, 4000, ETHERNET_DISABLE_SHAPER);
   #elif RMII
-    on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
-                                        i_rx_lp, NUM_RX_LP_IF,
-                                        i_tx_lp, NUM_TX_LP_IF,
-                                        c_rx_hp, c_tx_hp,
-                                        p_eth_clk,
-                                        &p_eth_rxd, p_eth_rxdv,
-                                        p_eth_txen, &p_eth_txd,
-                                        eth_rxclk, eth_txclk,
-                                        4000, 4000, ETHERNET_DISABLE_SHAPER);}
+    on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+                                    i_rx_lp, NUM_RX_LP_IF,
+                                    i_tx_lp, NUM_TX_LP_IF,
+                                    c_rx_hp, c_tx_hp,
+                                    p_eth_clk,
+                                    p_eth_rxd, p_eth_rxdv,
+                                    p_eth_txen, p_eth_txd,
+                                    eth_rxclk, eth_txclk,
+                                    4000, 4000, ETHERNET_DISABLE_SHAPER);
   #endif
     on tile[0]: filler(0x222);
     on tile[0]: filler(0x333);

--- a/tests/test_time_rx_tx/src/main_mii_rt.h
+++ b/tests/test_time_rx_tx/src/main_mii_rt.h
@@ -183,15 +183,15 @@ int main()
                                     eth_rxclk, eth_txclk,
                                     4000, 4000, ETHERNET_DISABLE_SHAPER);
   #elif RMII
-    on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
-                                        i_rx_lp, NUM_RX_LP_IF,
-                                        i_tx_lp, NUM_TX_LP_IF,
-                                        c_rx_hp, c_tx_hp,
-                                        p_eth_clk,
-                                        &p_eth_rxd, p_eth_rxdv,
-                                        p_eth_txen, &p_eth_txd,
-                                        eth_rxclk, eth_txclk,
-                                        4000, 4000, ETHERNET_DISABLE_SHAPER);}
+    on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+                                    i_rx_lp, NUM_RX_LP_IF,
+                                    i_tx_lp, NUM_TX_LP_IF,
+                                    c_rx_hp, c_tx_hp,
+                                    p_eth_clk,
+                                    p_eth_rxd, p_eth_rxdv,
+                                    p_eth_txen, p_eth_txd,
+                                    eth_rxclk, eth_txclk,
+                                    4000, 4000, ETHERNET_DISABLE_SHAPER);
   #endif
     on tile[0]: filler(0x1111);
 

--- a/tests/test_time_tx/src/main.xc
+++ b/tests/test_time_tx/src/main.xc
@@ -131,15 +131,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, 1,
-                        i_rx_lp, 1,
-                        i_tx_lp, 1,
-                        c_rx_hp, c_tx_hp,
-                        p_eth_clk,
-                        &p_eth_rxd, p_eth_rxdv,
-                        p_eth_txen, &p_eth_txd,
-                        eth_rxclk, eth_txclk,
-                        4000, 4000, ETHERNET_DISABLE_SHAPER);}
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, 1,
+                                        i_rx_lp, 1,
+                                        i_tx_lp, 1,
+                                        c_rx_hp, c_tx_hp,
+                                        p_eth_clk,
+                                        p_eth_rxd, p_eth_rxdv,
+                                        p_eth_txen, p_eth_txd,
+                                        eth_rxclk, eth_txclk,
+                                        4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
     on tile[0]: filler(0x1111);
     on tile[0]: filler(0x2222);

--- a/tests/test_timestamp_tx/src/main.xc
+++ b/tests/test_timestamp_tx/src/main.xc
@@ -105,15 +105,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, 1,
-                            i_rx_lp, 1,
-                            i_tx_lp, 1,
-                            null, null,
-                            p_eth_clk,
-                            &p_eth_rxd, p_eth_rxdv,
-                            p_eth_txen, &p_eth_txd,
-                            eth_rxclk, eth_txclk,
-                            4000, 4000, ETHERNET_DISABLE_SHAPER);}
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, 1,
+                                        i_rx_lp, 1,
+                                        i_tx_lp, 1,
+                                        null, null,
+                                        p_eth_clk,
+                                        p_eth_rxd, p_eth_rxdv,
+                                        p_eth_txen, p_eth_txd,
+                                        eth_rxclk, eth_txclk,
+                                        4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
     on tile[0]: filler(0x1111);
     on tile[0]: filler(0x2222);

--- a/tests/test_tx/src/main.xc
+++ b/tests/test_tx/src/main.xc
@@ -135,15 +135,15 @@ int main()
                                         eth_rxclk, eth_txclk,
                                         4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-        on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, 1,
-                            i_rx_lp, 1,
-                            i_tx_lp, 1,
-                            c_rx_hp, c_tx_hp,
-                            p_eth_clk,
-                            &p_eth_rxd, p_eth_rxdv,
-                            p_eth_txen, &p_eth_txd,
-                            eth_rxclk, eth_txclk,
-                            4000, 4000, ETHERNET_DISABLE_SHAPER);}
+        on tile[0]: rmii_ethernet_rt_mac(i_cfg, 1,
+                                        i_rx_lp, 1,
+                                        i_tx_lp, 1,
+                                        c_rx_hp, c_tx_hp,
+                                        p_eth_clk,
+                                        p_eth_rxd, p_eth_rxdv,
+                                        p_eth_txen, p_eth_txd,
+                                        eth_rxclk, eth_txclk,
+                                        4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
 
     on tile[0]: filler(0x1111);

--- a/tests/test_vlan_strip/src/main.xc
+++ b/tests/test_vlan_strip/src/main.xc
@@ -109,15 +109,15 @@ int main()
                                       eth_rxclk, eth_txclk,
                                       4000, 4000, ETHERNET_DISABLE_SHAPER);
     #elif RMII
-      on tile[0]: unsafe{rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
+      on tile[0]: rmii_ethernet_rt_mac(i_cfg, NUM_CFG_IF,
                                     i_rx_lp, NUM_RX_LP_IF,
                                     i_tx_lp, NUM_TX_LP_IF,
                                     null, null,
                                     p_eth_clk,
-                                    &p_eth_rxd, p_eth_rxdv,
-                                    p_eth_txen, &p_eth_txd,
+                                    p_eth_rxd, p_eth_rxdv,
+                                    p_eth_txen, p_eth_txd,
                                     eth_rxclk, eth_txclk,
-                                    4000, 4000, ETHERNET_DISABLE_SHAPER);}
+                                    4000, 4000, ETHERNET_DISABLE_SHAPER);
     #endif
 
     on tile[0]: filler(0x77);


### PR DESCRIPTION
https://github.com/xmos/lib_ethernet/issues/76

This seems to work. Two small downsides:


- XC cannot keep track of ports so will not know if data ports are re-used
- It does not like the on tile[x] prefix since it is not a port, it is an unsigned. So we cannot pass in ports from the XN file (unless we do some macro trickery perhaps)

So a question of what is the lesser evil