### PR TITLE
Add a separate function to clear the notification for mac restart ins…

### DIFF
--- a/lib_ethernet/api/ethernet.h
+++ b/lib_ethernet/api/ethernet.h
@@ -105,10 +105,11 @@ typedef interface ethernet_cfg_if {
    *  \param new_state  The new link state for the port.
    *  \param speed      The active link speed and duplex of the PHY.
    */
-  XC_CLEARS_NOTIFICATION void set_link_state(int ifnum, ethernet_link_state_t new_state, ethernet_speed_t speed);
+  void set_link_state(int ifnum, ethernet_link_state_t new_state, ethernet_speed_t speed);
 
 #if ENABLE_MAC_START_NOTIFICATION
   XC_NOTIFICATION slave void mac_started(); // Notify the phy driver that the mac has started
+  XC_CLEARS_NOTIFICATION void ack_mac_start();   // Ack mac restart. Implement only if the client requires to be notified of mac restarts
 #endif
 
   /** Get the current link state.

--- a/lib_ethernet/src/mii_ethernet_mac.xc
+++ b/lib_ethernet/src/mii_ethernet_mac.xc
@@ -118,6 +118,7 @@ static void mii_ethernet_aux(client mii_if i_mii,
 
     ethernet_init_filter_table(filter_info);
 
+
     while (1) {
       select {
       case i_rx[int i].get_index() -> size_t result:
@@ -281,6 +282,10 @@ static void mii_ethernet_aux(client mii_if i_mii,
         mii_packet_sent(mii_info);
         break;
 
+#if ENABLE_MAC_START_NOTIFICATION
+      case i_cfg[int i].ack_mac_start():
+        break;
+#endif
       case i_cfg[int i].set_link_state(int ifnum, ethernet_link_state_t status, ethernet_speed_t speed):
         if (link_status != status) {
           link_status = status;

--- a/lib_ethernet/src/mii_ethernet_rt_mac.xc
+++ b/lib_ethernet/src/mii_ethernet_rt_mac.xc
@@ -336,6 +336,10 @@ unsafe void mii_ethernet_server(mii_mempool_t rx_mem,
       memcpy(mac_address, r_mac_address, sizeof r_mac_address);
       break;
 
+#if ENABLE_MAC_START_NOTIFICATION
+    case i_cfg[int i].ack_mac_start():
+      break;
+#endif
     case i_cfg[int i].set_link_state(int ifnum, ethernet_link_state_t status, ethernet_speed_t speed):
       if (p_port_state->link_state != status) {
         p_port_state->link_state = status;

--- a/lib_ethernet/src/rgmii_buffering.xc
+++ b/lib_ethernet/src/rgmii_buffering.xc
@@ -739,6 +739,11 @@ void rgmii_ethernet_mac_config(server ethernet_cfg_if i_cfg[n],
         memcpy(mac_address, r_mac_address, sizeof r_mac_address);
         break;
 
+#if ENABLE_MAC_START_NOTIFICATION
+      case i_cfg[int i].ack_mac_start():
+        break;
+#endif
+
       case i_cfg[int i].set_link_state(int ifnum, ethernet_link_state_t status, ethernet_speed_t speed):
         unsafe {
           p_port_state->link_state = status;


### PR DESCRIPTION
…tead of overloading set_link_state().