### PR TITLE
Adding compiler flags and fixing warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
   * ADDED: Fix for out of range relocation when loading from constant or data pool
+  * FIXED: Build warnings (when built with -Wextra)
 
 4.0.1
 -----

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // This file relates to internal XMOS infrastructure and should be ignored by external users
 
-@Library('xmos_jenkins_shared_library@v0.38.0') _
+@Library('xmos_jenkins_shared_library@v0.39.0') _
 
 def clone_test_deps() {
   dir("${WORKSPACE}") {
@@ -11,7 +11,7 @@ def clone_test_deps() {
     sh "git -C hardware_test_tools checkout 2f9919c956f0083cdcecb765b47129d846948ed4"
 
     sh "git clone git@github0.xmos.com:xmos-int/xtagctl"
-    sh "git -C xtagctl checkout v2.0.0"
+    sh "git -C xtagctl checkout v2.2.0"
   }
 }
 
@@ -38,12 +38,12 @@ pipeline {
     )
     string(
       name: 'XMOSDOC_VERSION',
-      defaultValue: 'v6.3.1',
+      defaultValue: 'v7.3.0',
       description: 'The xmosdoc version'
     )
     string(
         name: 'INFR_APPS_VERSION',
-        defaultValue: 'v2.0.1',
+        defaultValue: 'v2.2.0',
         description: 'The infr_apps version'
     )
     choice(name: 'TEST_TYPE', choices: ['smoke', 'nightly'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,19 +2,6 @@
 
 @Library('xmos_jenkins_shared_library@v0.41.1') _
 
-def clone_test_deps() {
-  dir("${WORKSPACE}") {
-    sh "git clone git@github.com:xmos/test_support"
-    sh "git -C test_support checkout v2.0.0"
-
-    sh "git clone git@github.com:xmos/hardware_test_tools"
-    sh "git -C hardware_test_tools checkout 984b1e1176003fd55be08001db27aeb58f7a10c9"
-
-    sh "git clone git@github0.xmos.com:xmos-int/xtagctl"
-    sh "git -C xtagctl checkout v3.0.0"
-  }
-}
-
 getApproval()
 
 pipeline {
@@ -85,7 +72,7 @@ pipeline {
         stage('Library checks') {
           steps {
             warnError("lib checks") {
-              runLibraryChecks("${WORKSPACE}/${REPO_NAME}", "${params.INFR_APPS_VERSION}")
+              runRepoChecks("${WORKSPACE}/${REPO_NAME}")
             }
           }
         }
@@ -94,12 +81,6 @@ pipeline {
             dir("${REPO_NAME}") {
               warnError("Docs") {
                 buildDocs()
-                dir("examples/AN00120_100Mbit_ethernet_demo_rmii") {
-                  buildDocs()
-                }
-                dir("examples/AN00199_gigabit_ethernet_demo_explorerkit") {
-                  buildDocs()
-                }
               }
             }
           }
@@ -145,11 +126,8 @@ pipeline {
               createVenv()
               installPipfile(false)
             }
-            clone_test_deps()
             dir("${REPO_NAME}") {
               withVenv {
-                sh "pip install -e ../test_support"
-                sh "pip install -e ../hardware_test_tools"
                 withTools(params.TOOLS_VERSION) {
                   dir("tests") {
                     unstash 'test_bin'
@@ -195,13 +173,8 @@ pipeline {
               installPipfile(false)
             }
 
-            clone_test_deps()
-
             dir("${REPO_NAME}") {
               withVenv {
-                sh "pip install -e ../test_support"
-                sh "pip install -e ../hardware_test_tools"
-                sh "pip install -e ../xtagctl"
                 withTools(params.TOOLS_VERSION) {
                   dir("tests") {
                     // Build all apps in the examples directory
@@ -246,13 +219,8 @@ pipeline {
               installPipfile(false)
             }
 
-            clone_test_deps()
-
             dir("${REPO_NAME}") {
               withVenv {
-                sh "pip install -e ../test_support"
-                sh "pip install -e ../hardware_test_tools"
-                sh "pip install -e ../xtagctl"
                 withTools(params.TOOLS_VERSION) {
                   dir("tests") {
                     // Build all apps in the examples directory

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // This file relates to internal XMOS infrastructure and should be ignored by external users
 
-@Library('xmos_jenkins_shared_library@v0.39.0') _
+@Library('xmos_jenkins_shared_library@v0.41.1') _
 
 def clone_test_deps() {
   dir("${WORKSPACE}") {
@@ -13,12 +13,6 @@ def clone_test_deps() {
     sh "git clone git@github0.xmos.com:xmos-int/xtagctl"
     sh "git -C xtagctl checkout v3.0.0"
   }
-}
-
-def archiveLib(String repoName) {
-    sh "git -C ${repoName} clean -xdf"
-    sh "zip ${repoName}_sw.zip -r ${repoName}"
-    archiveArtifacts artifacts: "${repoName}_sw.zip", allowEmptyArchive: false
 }
 
 getApproval()
@@ -38,19 +32,18 @@ pipeline {
     )
     string(
       name: 'XMOSDOC_VERSION',
-      defaultValue: 'v7.3.0',
+      defaultValue: 'v7.4.0',
       description: 'The xmosdoc version'
     )
     string(
         name: 'INFR_APPS_VERSION',
-        defaultValue: 'v2.2.0',
+        defaultValue: 'v3.1.1',
         description: 'The infr_apps version'
     )
     choice(name: 'TEST_TYPE', choices: ['smoke', 'nightly'],
           description: 'Run tests with either a fixed seed or a randomly generated seed')
   }
   environment {
-    REPO = 'lib_ethernet'
     REPO_NAME = 'lib_ethernet'
     PIP_VERSION = "24.0"
     SEED = "12345"
@@ -58,7 +51,7 @@ pipeline {
   stages {
     stage('Build + Documentation') {
       agent {
-        label 'documentation&&linux&&x86_64'
+        label 'documentation && linux && x86_64'
       }
       stages {
         stage('Checkout') {
@@ -67,7 +60,7 @@ pipeline {
           }
           steps {
             println "Stage running on: ${env.NODE_NAME}"
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
@@ -78,7 +71,7 @@ pipeline {
         stage('Build examples') {
           steps {
             withTools(params.TOOLS_VERSION) {
-              dir("${REPO}/examples") {
+              dir("${REPO_NAME}/examples") {
                 script {
                   echo "Test Stage: SEED is ${env.SEED}"
                   // Build all apps in the examples directory
@@ -92,13 +85,13 @@ pipeline {
         stage('Library checks') {
           steps {
             warnError("lib checks") {
-              runLibraryChecks("${WORKSPACE}/${REPO}", "${params.INFR_APPS_VERSION}")
+              runLibraryChecks("${WORKSPACE}/${REPO_NAME}", "${params.INFR_APPS_VERSION}")
             }
           }
         }
         stage('Documentation') {
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               warnError("Docs") {
                 buildDocs()
                 dir("examples/AN00120_100Mbit_ethernet_demo_rmii") {
@@ -113,7 +106,7 @@ pipeline {
         }
         stage('Build tests') {
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 withTools(params.TOOLS_VERSION) {
                   dir("tests") {
@@ -122,12 +115,12 @@ pipeline {
                   }
                 } // withTools(params.TOOLS_VERSION)
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
         } // stage('Build tests')
         stage("Archive Lib") {
           steps {
-            archiveLib(REPO)
+            archiveSandbox(REPO_NAME)
           }
         } //stage("Archive Lib")
       } // stages
@@ -147,13 +140,13 @@ pipeline {
             label 'linux && x86_64'
           }
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
             }
             clone_test_deps()
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 sh "pip install -e ../test_support"
                 sh "pip install -e ../hardware_test_tools"
@@ -177,11 +170,11 @@ pipeline {
                   } // dir("tests")
                 } // withTools
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
           post {
             always {
-              archiveArtifacts artifacts: "${REPO}/tests/ifg_*.txt", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_*.txt", fingerprint: true, allowEmptyArchive: true
             }
             cleanup {
             xcoreCleanSandbox()
@@ -196,7 +189,7 @@ pipeline {
             PYTHON_VERSION = "3.12.3"
           }
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
@@ -204,7 +197,7 @@ pipeline {
 
             clone_test_deps()
 
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 sh "pip install -e ../test_support"
                 sh "pip install -e ../hardware_test_tools"
@@ -227,12 +220,12 @@ pipeline {
                   } // dir("tests")
                 } // withTools
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
           post {
             always {
-              archiveArtifacts artifacts: "${REPO}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
-              archiveArtifacts artifacts: "${REPO}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
             }
             cleanup {
               xcoreCleanSandbox()
@@ -247,7 +240,7 @@ pipeline {
             PYTHON_VERSION = "3.12.3"
           }
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
@@ -255,7 +248,7 @@ pipeline {
 
             clone_test_deps()
 
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 sh "pip install -e ../test_support"
                 sh "pip install -e ../hardware_test_tools"
@@ -278,12 +271,12 @@ pipeline {
                   } // dir("tests")
                 } // withTools
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
           post {
             always {
-              archiveArtifacts artifacts: "${REPO}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
-              archiveArtifacts artifacts: "${REPO}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
             }
             cleanup {
               xcoreCleanSandbox()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ def clone_test_deps() {
     sh "git -C hardware_test_tools checkout 2f9919c956f0083cdcecb765b47129d846948ed4"
 
     sh "git clone git@github0.xmos.com:xmos-int/xtagctl"
-    sh "git -C xtagctl checkout v2.2.0"
+    sh "git -C xtagctl checkout v3.0.0"
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,24 +1,18 @@
 // This file relates to internal XMOS infrastructure and should be ignored by external users
 
-@Library('xmos_jenkins_shared_library@v0.39.0') _
+@Library('xmos_jenkins_shared_library@v0.41.1') _
 
 def clone_test_deps() {
   dir("${WORKSPACE}") {
     sh "git clone git@github.com:xmos/test_support"
-    sh "git -C test_support checkout e62b73a1260069c188a7d8fb0d91e1ef80a3c4e1"
+    sh "git -C test_support checkout v2.0.0"
 
     sh "git clone git@github.com:xmos/hardware_test_tools"
-    sh "git -C hardware_test_tools checkout 2f9919c956f0083cdcecb765b47129d846948ed4"
+    sh "git -C hardware_test_tools checkout 984b1e1176003fd55be08001db27aeb58f7a10c9"
 
     sh "git clone git@github0.xmos.com:xmos-int/xtagctl"
     sh "git -C xtagctl checkout v3.0.0"
   }
-}
-
-def archiveLib(String repoName) {
-    sh "git -C ${repoName} clean -xdf"
-    sh "zip ${repoName}_sw.zip -r ${repoName}"
-    archiveArtifacts artifacts: "${repoName}_sw.zip", allowEmptyArchive: false
 }
 
 getApproval()
@@ -43,14 +37,13 @@ pipeline {
     )
     string(
         name: 'INFR_APPS_VERSION',
-        defaultValue: 'v2.2.0',
+        defaultValue: 'v3.1.1',
         description: 'The infr_apps version'
     )
     choice(name: 'TEST_TYPE', choices: ['smoke', 'nightly'],
           description: 'Run tests with either a fixed seed or a randomly generated seed')
   }
   environment {
-    REPO = 'lib_ethernet'
     REPO_NAME = 'lib_ethernet'
     PIP_VERSION = "24.0"
     SEED = "12345"
@@ -58,7 +51,7 @@ pipeline {
   stages {
     stage('Build + Documentation') {
       agent {
-        label 'documentation&&linux&&x86_64'
+        label 'documentation && linux && x86_64'
       }
       stages {
         stage('Checkout') {
@@ -67,7 +60,7 @@ pipeline {
           }
           steps {
             println "Stage running on: ${env.NODE_NAME}"
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
@@ -78,7 +71,7 @@ pipeline {
         stage('Build examples') {
           steps {
             withTools(params.TOOLS_VERSION) {
-              dir("${REPO}/examples") {
+              dir("${REPO_NAME}/examples") {
                 script {
                   echo "Test Stage: SEED is ${env.SEED}"
                   // Build all apps in the examples directory
@@ -92,13 +85,13 @@ pipeline {
         stage('Library checks') {
           steps {
             warnError("lib checks") {
-              runLibraryChecks("${WORKSPACE}/${REPO}", "${params.INFR_APPS_VERSION}")
+              runLibraryChecks("${WORKSPACE}/${REPO_NAME}", "${params.INFR_APPS_VERSION}")
             }
           }
         }
         stage('Documentation') {
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               warnError("Docs") {
                 buildDocs()
                 dir("examples/AN00120_100Mbit_ethernet_demo_rmii") {
@@ -113,7 +106,7 @@ pipeline {
         }
         stage('Build tests') {
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 withTools(params.TOOLS_VERSION) {
                   dir("tests") {
@@ -122,12 +115,12 @@ pipeline {
                   }
                 } // withTools(params.TOOLS_VERSION)
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
         } // stage('Build tests')
         stage("Archive Lib") {
           steps {
-            archiveLib(REPO)
+            archiveSandbox(REPO_NAME)
           }
         } //stage("Archive Lib")
       } // stages
@@ -147,13 +140,13 @@ pipeline {
             label 'linux && x86_64'
           }
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
             }
             clone_test_deps()
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 sh "pip install -e ../test_support"
                 sh "pip install -e ../hardware_test_tools"
@@ -177,11 +170,11 @@ pipeline {
                   } // dir("tests")
                 } // withTools
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
           post {
             always {
-              archiveArtifacts artifacts: "${REPO}/tests/ifg_*.txt", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_*.txt", fingerprint: true, allowEmptyArchive: true
             }
             cleanup {
             xcoreCleanSandbox()
@@ -196,7 +189,7 @@ pipeline {
             PYTHON_VERSION = "3.12.3"
           }
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
@@ -204,7 +197,7 @@ pipeline {
 
             clone_test_deps()
 
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 sh "pip install -e ../test_support"
                 sh "pip install -e ../hardware_test_tools"
@@ -227,12 +220,12 @@ pipeline {
                   } // dir("tests")
                 } // withTools
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
           post {
             always {
-              archiveArtifacts artifacts: "${REPO}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
-              archiveArtifacts artifacts: "${REPO}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
             }
             cleanup {
               xcoreCleanSandbox()
@@ -247,7 +240,7 @@ pipeline {
             PYTHON_VERSION = "3.12.3"
           }
           steps {
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               checkoutScmShallow()
               createVenv()
               installPipfile(false)
@@ -255,7 +248,7 @@ pipeline {
 
             clone_test_deps()
 
-            dir("${REPO}") {
+            dir("${REPO_NAME}") {
               withVenv {
                 sh "pip install -e ../test_support"
                 sh "pip install -e ../hardware_test_tools"
@@ -278,12 +271,12 @@ pipeline {
                   } // dir("tests")
                 } // withTools
               } // withVenv
-            } // dir("${REPO}")
+            } // dir("${REPO_NAME}")
           } // steps
           post {
             always {
-              archiveArtifacts artifacts: "${REPO}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
-              archiveArtifacts artifacts: "${REPO}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
             }
             cleanup {
               xcoreCleanSandbox()

--- a/doc/rst/lib_ethernet.rst
+++ b/doc/rst/lib_ethernet.rst
@@ -42,10 +42,10 @@ Various MAC blocks are available depending on the XMOS architecture selected, de
 
 The MII MAC is available as two types; a low resource usage version which provides standard layer 2 data access to an array of clients, and a real-time version which offers additional hardware features including:
 
- * Hardware time-stamping of point of ingress and egress of frames supporting standards such as IEEE 802.1AS.
- * Support for high priority send and receive queues and receive filtering. This allows time sensitive traffic to be prioritised over other traffic.
- * Traffic shaping on egress using an IEEE 802.1Qav compliant credit based shaper.
- * Configurable VLAN tag stripping on received frames.
+* Hardware time-stamping of point of ingress and egress of frames supporting standards such as IEEE 802.1AS.
+* Support for high priority send and receive queues and receive filtering. This allows time sensitive traffic to be prioritised over other traffic.
+* Traffic shaping on egress using an IEEE 802.1Qav compliant credit based shaper.
+* Configurable VLAN tag stripping on received frames.
 
 All RMII and RGMII implementations offer the 'real-time' features as standard. See the :ref:`rt_mac_section` section for more details.
 
@@ -60,9 +60,13 @@ Usage
 
 To use ``lib_ethernet`` in an application, add ``lib_ethernet``, to the list of dependent modules in the application's `CMakeLists.txt` file.
 
+.. code-block:: cmake
+
   set(APP_DEPENDENT_MODULES "lib_ethernet")
 
-All `lib_ethernet` functions can be accessed via the ``ethernet.h`` header file::
+All `lib_ethernet` functions can be accessed via the ``ethernet.h`` header file
+
+.. code-block:: C
 
   #include <ethernet.h>
 
@@ -152,12 +156,12 @@ Feature Overview
 
 All MACs in this library support a number of useful features which can be configured by clients.
 
-  * Support for multiple clients (Rx and Tx) allowing many tasks to share the MAC.
-  * Configurable Ethertype and MAC address filters for unicast, multicast and broadcast addresses and is configurable per client. The number of entries is configurable using ``ETHERNET_MACADDR_FILTER_TABLE_SIZE``.
-  * Configurable source MAC address. This may be used in conjunction with, for example, lib_otp to provide a unique MAC address per XMOS chip.
-  * Link state detection allowing action to be taken by higher layers in the case of link state change.
-  * Separately configurable Rx and Tx buffer sizes (queues).
-  * VLAN aware received packet length calculation. If the VLAN tag (0x8100) is seen the header length is automatically extended by 4 octets to support the Tag Protocol Identifier (TPID) and Tag Control Information (TCI).
+* Support for multiple clients (Rx and Tx) allowing many tasks to share the MAC.
+* Configurable Ethertype and MAC address filters for unicast, multicast and broadcast addresses and is configurable per client. The number of entries is configurable using ``ETHERNET_MACADDR_FILTER_TABLE_SIZE``.
+* Configurable source MAC address. This may be used in conjunction with, for example, lib_otp to provide a unique MAC address per XMOS chip.
+* Link state detection allowing action to be taken by higher layers in the case of link state change.
+* Separately configurable Rx and Tx buffer sizes (queues).
+* VLAN aware received packet length calculation. If the VLAN tag (0x8100) is seen the header length is automatically extended by 4 octets to support the Tag Protocol Identifier (TPID) and Tag Control Information (TCI).
 
 Transmission of packets is via an API that blocks until the frame has been copied into the transmit queue. This means the buffer size should be appropriately sized for your application or the application should tolerate blocking.
 
@@ -224,9 +228,9 @@ The Credit Based Shaper (CBS), in conjunction with the HP queue, limits the band
 
 The CBS uses the following mechanisms to manage egress rate:
 
-  * Credits: The high priority queue is assigned a "credit" that increases or decreases over time based on the network's traffic conditions.
-  * Idle Slope: Determines how quickly credit increases when the queue is idle (i.e., waiting to transmit).
-  * Transmission of data decreases credit proportionally to the number of bits sent.
+* Credits: The high priority queue is assigned a "credit" that increases or decreases over time based on the network's traffic conditions.
+* Idle Slope: Determines how quickly credit increases when the queue is idle (i.e., waiting to transmit).
+* Transmission of data decreases credit proportionally to the number of bits sent.
 
 If the credit is positive, the high priority stream is eligible for transmission and will always be transmitted before any low priority traffic. If the credit is negative, the high priority stream is paused until the credit returns to a positive state. By spreading traffic out evenly over time using a CBS, the queue size in each bridge and endpoint can be shorter, which in turn reduces the latency experienced by traffic as it flows through the system.
 
@@ -381,11 +385,11 @@ The detail for how to set the values is outside the scope of this document, howe
 
 In summary, the fields (and their uses) in the ``port_timing`` structure are as follows:
 
- * clk_delay_tx_rising - The number of core clock cycles to delay the capture clock. Since no signal capture occurs in the TX section this value is not critical, however it should be set to the same as clk_delay_tx_falling.
- * clk_delay_tx_falling - The number of core clock cycles to delay the drive clock falling edge. Increasing this value delays the presentation of the TX data and TXEN signal relative to the external ethernet clock.
- * clk_delay_rx_rising - The number of core clock cycles to delay the capture clock. Increasing this value delays the point at which the RX data and RXDV are sampled relative to the external ethernet clock.
- * clk_delay_rx_falling - The number of core clock cycles to delay the drive clock. Since no signal drive occurs in the RX section this value is not critical, however it should be set to the same as clk_delay_rx_rising.
- * pad_delay_rx - The number of core clock cycles to delay the sampling of RX data and strobe. Because this setting delays the data and not the clock, it has the effect of adding negative clock delay, which can be useful in some cases.
+* clk_delay_tx_rising - The number of core clock cycles to delay the capture clock. Since no signal capture occurs in the TX section this value is not critical, however it should be set to the same as clk_delay_tx_falling.
+* clk_delay_tx_falling - The number of core clock cycles to delay the drive clock falling edge. Increasing this value delays the presentation of the TX data and TXEN signal relative to the external ethernet clock.
+* clk_delay_rx_rising - The number of core clock cycles to delay the capture clock. Increasing this value delays the point at which the RX data and RXDV are sampled relative to the external ethernet clock.
+* clk_delay_rx_falling - The number of core clock cycles to delay the drive clock. Since no signal drive occurs in the RX section this value is not critical, however it should be set to the same as clk_delay_rx_rising.
+* pad_delay_rx - The number of core clock cycles to delay the sampling of RX data and strobe. Because this setting delays the data and not the clock, it has the effect of adding negative clock delay, which can be useful in some cases.
 
 
 
@@ -477,9 +481,9 @@ Other IO pins and ports are unaffected.
 |newpage|
 
 
-*****
-Usage
-*****
+**********************
+Using ``lib_ethernet``
+**********************
 
 10/100 Mb/s Ethernet MAC operation
 ==================================
@@ -505,7 +509,9 @@ can connect via a transmit, receive and configuration interface connection using
 
    10/100 Mb/s Ethernet MAC task diagram
 
-For example, the following code instantiates a standard Ethernet MAC component using MII and connects to it::
+For example, the following code instantiates a standard Ethernet MAC component using MII and connects to it.
+
+.. code-block:: c
 
   port p_eth_rxclk  = XS1_PORT_1J;
   port p_eth_rxd    = XS1_PORT_4E;
@@ -536,7 +542,9 @@ For example, the following code instantiates a standard Ethernet MAC component u
 Note that the connections are arrays of interfaces, so several tasks can connect to the same component instance.
 
 The application can use the client end of the interface connections to
-perform Ethernet MAC operations e.g.::
+perform Ethernet MAC operations e.g.
+
+.. code-block:: c
 
   void application(client ethernet_cfg_if i_cfg,
                    client ethernet_rx_if i_rx,
@@ -560,7 +568,6 @@ perform Ethernet MAC operations e.g.::
     }
   }
 
-
 |newpage|
 
 10/100 Mb/s real-time Ethernet MAC
@@ -582,7 +589,9 @@ receiving high-priority Ethernet traffic, as shown in :numref:`rt_mac_task_diagr
    10/100 Mb/s real-time Ethernet MAC task diagram
 
 For example, the following code instantiates a real-time Ethernet MAC component with connected via MII high and low-priority
-interfaces and connects to it::
+interfaces and connects to it
+
+.. code-block:: c
 
   port p_eth_rxclk  = XS1_PORT_1J;
   port p_eth_rxd    = XS1_PORT_4E;
@@ -613,7 +622,9 @@ interfaces and connects to it::
 
 
 
-Similarly the RMII real-time MAC may be instantiated (four bit port version shown)::
+Similarly the RMII real-time MAC may be instantiated (four bit port version shown).
+
+.. code-block:: c
 
     port p_eth_clk = XS1_PORT_1J;
     port p_eth_txd = XS1_PORT_4B;
@@ -647,7 +658,9 @@ Similarly the RMII real-time MAC may be instantiated (four bit port version show
 
 
 
-The application can use the other end of the streaming channels to send and receive high-priority traffic e.g.::
+The application can use the other end of the streaming channels to send and receive high-priority traffic e.g.
+
+.. code-block:: c
 
   void application(client ethernet_cfg_if i_cfg,
                    client ethernet_rx_if i_rx,
@@ -693,7 +706,9 @@ and the user application run on Tile 0, as shown in :numref:`rgmii_mac_task_diag
 
 
 For example, the following code instantiates a 10/100/1000 Mb/s Ethernet MAC component with high and low-priority
-interfaces and connects to it::
+interfaces and connects to it
+
+.. code-block:: c
 
   rgmii_ports_t rgmii_ports = on tile[1]: RGMII_PORTS_INITIALIZER;
 
@@ -735,7 +750,9 @@ consumes some of the MIPs on that core in addition to the core :ref:`mii` is run
 
    MII task diagram
 
-For example, the following code instantiates a MII component and connects to it::
+For example, the following code instantiates a MII component and connects to it.
+
+.. code-block:: c
 
   port p_eth_rxclk  = XS1_PORT_1J;
   port p_eth_rxd    = XS1_PORT_4E;
@@ -780,9 +797,11 @@ The interface uses two pins to communicate and there are two variants of the API
 .. note::
     The standard SMI/MDIO specification requires use of a pull-up resistor on MDIO (typically 4.7 kOhm for a single PHY in a 3.3 V system). If using the single-port version then it is necessary to also connect a pull-up to the MDC line (typically 4.7 kOhm for 3.3 V systems). The reason for this is that xcore ports have only a single direction bit. So in order to sample the MDIO line with a known MDC state, an external resistor is required.
 
-The speed of the interface is set conservatively at 1.66 MHz which supports slower PHY SMI interfaces (eg. LAN8710A) that have a relatively slow time to data valid. This speed is also chosen to support the single port version which has to sample read data at the falling edge, effectively reducing the maximum bit clock by a factor of two. If faster access is required and supported by the PHY, or the two port version is used, then it is possible to adjust the following define in ``smi.xc`` up to a maximum of around 4 MHz for xCORE-200 and 5 MHz for xcore.ai::
+The speed of the interface is set conservatively at 1.66 MHz which supports slower PHY SMI interfaces (eg. LAN8710A) that have a relatively slow time to data valid. This speed is also chosen to support the single port version which has to sample read data at the falling edge, effectively reducing the maximum bit clock by a factor of two. If faster access is required and supported by the PHY, or the two port version is used, then it is possible to adjust the following define in ``smi.xc`` up to a maximum of around 4 MHz for xCORE-200 and 5 MHz for xcore.ai.
 
-    #define SMI_BIT_CLOCK_HZ 1660000
+.. code-block:: c
+
+  #define SMI_BIT_CLOCK_HZ 1660000
 
 Increasing the bit clock may require use of smaller pull-up resistor(s) depending on board layout to ensure that the signal rise time is sufficient. If in doubt, either test operation using lower the bit rate by setting a smaller ``SMI_BIT_CLOCK_HZ`` or check with an oscilloscope to ensure that the MDC and MDIO lines are fully reaching the logic high state.
 
@@ -794,12 +813,14 @@ Increasing the bit clock may require use of smaller pull-up resistor(s) dependin
 API
 ***
 
-All Ethernet functions can be accessed via the ``ethernet.h`` header::
+All Ethernet functions can be accessed via the ``ethernet.h`` header.
+
+.. code-block:: c
 
   #include <ethernet.h>
 
 You will also have to add ``lib_ethernet`` to the
-``USED_MODULES`` field of your application Makefile.
+``APP_DEPENDENT_MODULES`` field of your application `CmakeLists.txt` file.
 
 Creating a 10/100 Mb/s Ethernet MAC instance
 ============================================
@@ -834,6 +855,8 @@ Creating a 10/100/1000 Mb/s Ethernet MAC instance
 .. doxygenfunction:: rgmii_ethernet_mac_config
 
 |newpage|
+
+.. c:namespace-push:: ethernet_namespace
 
 .. _ethernet_cfg_if:
 
@@ -876,12 +899,18 @@ The Ethernet MAC high-priority data handling interface
 
 .. doxygenfunction:: ethernet_receive_hp_packet
 
+.. c:namespace-pop::
+
 |newpage|
+
+.. c:namespace-push:: mii_namespace
 
 Creating a raw MII instance
 ===========================
 
-All raw MII functions can be accessed via the ``mii.h`` header::
+All raw MII functions can be accessed via the ``mii.h`` header.
+
+.. code-block:: c
 
   #include <mii.h>
 
@@ -892,7 +921,7 @@ The MII interface
 
 .. _mii_if_section:
 
-.. doxygengroup:: mii_if
+.. doxygengroup::  mii_if
 
 .. doxygenfunction:: mii_incoming_packet
 
@@ -905,8 +934,10 @@ The MII interface
 Creating an SMI/MDIO instance
 =============================
 
-All SMI functions can be accessed via the ``smi.h`` header::
+All SMI functions can be accessed via the ``smi.h`` header.
 
+.. code-block:: c
+  
   #include <smi.h>
 
 .. doxygenfunction:: smi
@@ -936,3 +967,5 @@ SMI PHY configuration helper functions
 .. doxygenfunction:: smi_phy_is_powered_down
 
 .. doxygenfunction:: smi_get_link_state
+
+.. c:namespace-pop::

--- a/lib_ethernet/api/ethernet.h
+++ b/lib_ethernet/api/ethernet.h
@@ -463,6 +463,7 @@ inline void ethernet_send_hp_packet(streaming_chanend_t c_tx_hp,
                                     unsigned n,
                                     unsigned ifnum)
 {
+  (void)ifnum;
   c_tx_hp <: n;
   sout_char_array(c_tx_hp, packet, n);
 }

--- a/lib_ethernet/api/ethernet.h
+++ b/lib_ethernet/api/ethernet.h
@@ -117,9 +117,9 @@ typedef interface ethernet_cfg_if {
    *
    *  This function Gets the current link state and speed of the PHY to the MAC.
    *
-   *  \param ifnum      The index of the MAC interface to ge the link state for
-   *
-   *  \returns Ethernet link state and speed
+   *  \param ifnum      The index of the MAC interface to get the link state for
+   *  \param link_state The current link state of the port.
+   *  \param link_speed The current link speed.
    */
   void get_link_state(int ifnum, REFERENCE_PARAM(unsigned, link_state), REFERENCE_PARAM(unsigned, link_speed));
 
@@ -207,8 +207,8 @@ typedef interface ethernet_cfg_if {
   /** Set the high-priority TX queue's credit based shaper idle slope in bits per second.
    *  This function is only available in the 10/100 Mb/s real-time and 10/100/1000 Mb/s MACs.
    *
-   *  \param ifnum   The index of the MAC interface to set the slope (always 0)
-   *  \param slope   The maximum number of bits per second to be set
+   *  \param ifnum            The index of the MAC interface to set the slope (always 0)
+   *  \param bits_per_second  The maximum number of bits per second to be set
    *
    *
    */
@@ -217,9 +217,9 @@ typedef interface ethernet_cfg_if {
 
   /** Sets the the high-priority TX queue's  Qav credit limit in units of frame size bytes
    *
-   *  \param ifnum         The index of the MAC interface to set the slope (always 0)
-   *  \param limit_bytes   The credit limit in units of payload size in bytes to set as a credit limit,
-   *                       not including preamble, CRC and IFG. Set to 0 for no limit (default)
+   *  \param ifnum                The index of the MAC interface to set the slope (always 0)
+   *  \param payload_limit_bytes  The credit limit in units of payload size in bytes to set as a credit limit,
+   *                              not including preamble, CRC and IFG. Set to 0 for no limit (default)
    *
    */
   void set_egress_qav_credit_limit(size_t ifnum, int payload_limit_bytes);

--- a/lib_ethernet/lib_build_info.cmake
+++ b/lib_ethernet/lib_build_info.cmake
@@ -7,7 +7,7 @@ set(LIB_INCLUDES            api
 
 set(LIB_DEPENDENT_MODULES   "lib_locks(2.3.1)"
                             "lib_logging(3.3.1)"
-                            "lib_xassert(4.3.1)")
+                            "lib_xassert(4.3.2)")
 
 set(LIB_COMPILER_FLAGS      -g
                             -O3

--- a/lib_ethernet/lib_build_info.cmake
+++ b/lib_ethernet/lib_build_info.cmake
@@ -11,6 +11,12 @@ set(LIB_DEPENDENT_MODULES   "lib_locks(2.3.1)"
 
 set(LIB_COMPILER_FLAGS      -g
                             -O3
+                            -Wall
+                            -Wextra
+                            -Wconversion
+                            -Wdiv-by-zero
+                            -Wfloat-equal
+                            -Wsign-compare
                             -mno-dual-issue)
 
 set(LIB_OPTIONAL_HEADERS    ethernet_conf.h)

--- a/lib_ethernet/src/macaddr_filter_hash.c
+++ b/lib_ethernet/src/macaddr_filter_hash.c
@@ -52,15 +52,15 @@ void mii_macaddr_set_num_active_filters(unsigned num_active)
 static inline void entry_to_keys(ethernet_macaddr_filter_t entry,
                                  unsigned *key0, unsigned *key1)
 {
-  *key0 = entry.addr[0] <<  0 |
-          entry.addr[1] <<  8 |
-          entry.addr[2] << 16 |
-          entry.addr[3] << 24;
-  *key1 = entry.addr[4] <<  0 |
-          entry.addr[5] <<  8;
+  *key0 = (unsigned)entry.addr[0] <<  0 |
+          (unsigned)entry.addr[1] <<  8 |
+          (unsigned)entry.addr[2] << 16 |
+          (unsigned)entry.addr[3] << 24;
+  *key1 = (unsigned)entry.addr[4] <<  0 |
+          (unsigned)entry.addr[5] <<  8;
 }
 
-static inline int hash(int key0, int key1, int poly)
+static inline unsigned int hash(unsigned int key0, unsigned int key1, unsigned int poly)
 {
   unsigned int x = key0;
 
@@ -140,7 +140,7 @@ static int insert(unsigned key0, unsigned key1,
   current.result = result;
   current.appdata = appdata;
   do {
-    int index = hash(current.id[0], current.id[1], backup_table->polys[hashtype]);
+    unsigned int index = hash(current.id[0], current.id[1], backup_table->polys[hashtype]);
 
     int empty = 0;
     if (!contains_different_entry(index, current.id, &empty)) {

--- a/lib_ethernet/src/mii_lite_driver.xc
+++ b/lib_ethernet/src/mii_lite_driver.xc
@@ -90,6 +90,7 @@ static int CRCBad(int base, int end) {
 }
 
 static int packet_good(struct mii_lite_data_t &this, int base, int end) {
+  UNUSED(this);
   int length = CRCBad(base, end);
   return length;
 }

--- a/lib_ethernet/src/mii_ts_queue.c
+++ b/lib_ethernet/src/mii_ts_queue.c
@@ -3,7 +3,7 @@
 #include "mii_ts_queue.h"
 #include "mii_buffering.h"
 
-mii_ts_queue_t mii_ts_queue_init(mii_ts_queue_info_t *q, mii_ts_queue_entry_t *buf, int n)
+mii_ts_queue_t mii_ts_queue_init(mii_ts_queue_info_t *q, mii_ts_queue_entry_t *buf, unsigned int n)
 {
   q->num_entries = n;
   q->fifo = (mii_ts_queue_entry_t *)buf;
@@ -50,7 +50,7 @@ int mii_ts_queue_get_entry(mii_ts_queue_t q, unsigned *id, unsigned *timestamp)
     swlock_acquire((swlock_t *) q->lock);
   }
 
-  unsigned found = 0;
+  int found = 0;
   unsigned rd_index = q->rd_index;
   if (rd_index != q->wr_index) {
     found = 1;

--- a/lib_ethernet/src/mii_ts_queue.h
+++ b/lib_ethernet/src/mii_ts_queue.h
@@ -23,7 +23,7 @@ typedef struct mii_ts_queue_info_t {
 
 typedef mii_ts_queue_info_t *mii_ts_queue_t;
 
-mii_ts_queue_t mii_ts_queue_init(mii_ts_queue_info_t *q, mii_ts_queue_entry_t *buf, int n);
+mii_ts_queue_t mii_ts_queue_init(mii_ts_queue_info_t *q, mii_ts_queue_entry_t *buf, unsigned int n);
 
 void mii_ts_queue_add_entry(mii_ts_queue_t q, unsigned id, unsigned timestamp);
 

--- a/lib_ethernet/src/rgmii_10_100_master.xc
+++ b/lib_ethernet/src/rgmii_10_100_master.xc
@@ -225,6 +225,8 @@ unsafe void rgmii_10_100_master_rx_pins(streaming chanend c,
       "zip %0, %1, 2" : "=&r"(tmp1), "=&r"(tmp2) : "r"(a), "r"(b));
   return {tmp1, tmp2};
 #else
+  (void)a;
+  (void)b;
   __builtin_trap();
   return {0, 0};
 #endif

--- a/lib_ethernet/src/rgmii_ethernet_mac.xc
+++ b/lib_ethernet/src/rgmii_ethernet_mac.xc
@@ -22,6 +22,8 @@ void enable_rgmii(unsigned delay, unsigned divide) {
         XS1_XCORE_CTRL0_RGMII_DIVIDE_SET(
           XS1_XCORE_CTRL0_RGMII_ENABLE_SET(rdata, 0x1), divide), delay));
 #else
+  (void)delay;
+  (void)divide;
   fail("RGMII not available on XS1");
 #endif
 }

--- a/lib_ethernet/src/shaper.h
+++ b/lib_ethernet/src/shaper.h
@@ -36,9 +36,9 @@ void set_qav_idle_slope(volatile ethernet_port_state_t * unsafe port_state, unsi
 
 /** Sets the Qav credit limit in units of frame size byte
  *
- *   \param port_state    Pointer to the port state to be modified
- *   \param limit_bytes   The credit limit in units of payload size in bytes to set as a credit limit,
- *                        not including preamble, CRC and IFG. Set to 0 for no limit (default)
+ *   \param port_state            Pointer to the port state to be modified
+ *   \param payload_limit_bytes   The credit limit in units of payload size in bytes to set as a credit limit,
+ *                                not including preamble, CRC and IFG. Set to 0 for no limit (default)
  *
  */
 void set_qav_credit_limit(volatile ethernet_port_state_t * unsafe port_state, int payload_limit_bytes);

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,6 @@ pytest-timeout==2.3.1
 # setup.py file, e.g., '-e .' or '-e ./python' (without the quotes).
 
 -e ./python
+-e git+ssh://git@github.com/xmos/test_support.git@e62b73a1260069c188a7d8fb0d91e1ef80a3c4e1#egg=test_support
+-e git+ssh://git@github.com/xmos/hardware_test_tools.git@2f9919c956f0083cdcecb765b47129d846948ed4#egg=hardware_test_tools
+-e git+ssh://git@github0.xmos.com/xmos-int/xtagctl.git@v3.0.0#egg=xtagctl


### PR DESCRIPTION
Still need to figure out how to silence warnings for unused parameters of type chanend.

This PR currently depends on a amcro in xassert:develop. See if we can get a minor release of that out... mow released thanks to Ross