### PR TITLE
Moving test board_support to lib_ethernet. 

### DIFF
--- a/tests/board_support/api/test_boards_utils.h
+++ b/tests/board_support/api/test_boards_utils.h
@@ -1,0 +1,41 @@
+// Copyright 2024-2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#pragma once
+
+#include <xs1.h>
+
+#ifdef __test_board_support_conf_h_exists__
+    #include "test_board_support_conf.h"
+#endif
+
+/**
+ * \addtogroup test_bs_common
+ *
+ * The common defines for using test_board_support.
+ * @{
+ */
+
+/* List of supported boards */
+
+/** Define representing Null board i.e. no board in use*/
+#define NULL_BOARD                  0
+
+/** Define representing XK-ETH-XU316-DUAL-100M board */
+#define XK_ETH_XU316_DUAL_100M      0xF0
+
+/** Total number of boards supported by the library */
+#define TEST_BOARD_SUPPORT_N_BOARDS 1  // max board + 1
+
+/** Define that should be set to the current board type in use
+  *
+  * Default value: NULL_BOARD
+  */
+#ifndef TEST_BOARD_SUPPORT_BOARD
+#define TEST_BOARD_SUPPORT_BOARD    NULL_BOARD /** This means none of the BSP sources are compiled in to the project */
+#endif
+
+#if TEST_BOARD_SUPPORT_BOARD != XK_ETH_XU316_DUAL_100M
+#error Invalid board selected
+#endif
+
+/**@}*/ // END: addtogroup test_bs_common

--- a/tests/board_support/api/xk_eth_xu316_dual_100m/board.h
+++ b/tests/board_support/api/xk_eth_xu316_dual_100m/board.h
@@ -1,0 +1,79 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef __XK_ETH_XU316_DUAL_100M_BOARD_H__
+#define __XK_ETH_XU316_DUAL_100M_BOARD_H__
+
+#include "test_boards_utils.h"
+#if (TEST_BOARD_SUPPORT_BOARD == XK_ETH_XU316_DUAL_100M) || defined(__DOXYGEN__)
+#include <xccompat.h>
+#include "smi.h"
+
+#ifndef NULLABLE_CLIENT_INTERFACE
+#ifdef __XC__
+#define NULLABLE_CLIENT_INTERFACE(tag, name) client interface tag ?name
+#else
+#define NULLABLE_CLIENT_INTERFACE(type, name) unsigned name
+#endif
+#endif // NULLABLE_CLIENT_INTERFACE
+
+
+/**
+ * \addtogroup xk_eth_xu316_dual_100m
+ *
+ * API for the xk_eth_xu316_dual_100m board.
+ * @{
+ */
+
+ /** Index value used with get_port_timings() to refer to board configuration.
+  *
+  * The timings change according to which PHYs mounted and the hardware configuration
+  * of the dual PHY dev-kit.
+  */
+typedef enum {
+    DUAL_PHY_MOUNTED_PHY0,
+    DUAL_PHY_MOUNTED_PHY1,
+    SINGLE_PHY_MOUNTED_PHY0,
+} port_timing_index_t;
+
+/** Task that connects to the SMI master and MAC to configure the
+ * DP83826E PHYs and monitor the link status. Note this task is combinable
+ * (typically with SMI) and therefore does not need to take a whole thread.
+ *
+ * Note it may be necessary to modify R3 and R23 according to which
+ * PHY is used. Populate R23 and remove R3 for PHY_0 only populated otherwise
+ * populate R3 and remove R23 for all other settings.
+ *
+ *  \param i_smi        Client register read/write interface
+ *  \param i_eth_phy_0  Client MAC configuration interface for PHY_0. Set to NULL if unused.
+ *  \param i_eth_phy_1  Client MAC configuration interface for PHY_1. Set to NULL if unused.
+ */
+[[combinable]]
+void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
+                              NULLABLE_CLIENT_INTERFACE(ethernet_cfg_if, i_eth_phy_0),
+                              NULLABLE_CLIENT_INTERFACE(ethernet_cfg_if, i_eth_phy_1));
+
+/** Sends hard reset to both PHYs. Both PHYs will be ready for SMI
+ * communication once this function has returned.
+ * This function must be called from Tile[1].
+ *
+ */
+void reset_eth_phys(void);
+
+/** Returns a timing struct tuned to the xk_eth_xu316_dual_100m hardware.
+ * This struct should be passed to the call to rmii_ethernet_rt_mac() and will
+ * ensure setup and hold times are maximised at the pin level of the PHY connection.
+ * rmii_port_timing_t is defined in lib_ethernet.
+ *
+ *  \param phy_idx      The index of the PHY to get timing data about.
+ *  \returns            The timing struct to be passed to the PHY.
+ */
+rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx);
+
+
+/**@}*/ // END: addtogroup xk_eth_xu316_dual_100m
+
+#endif // (TEST_BOARD_SUPPORT_BOARD == XK_ETH_XU316_DUAL_100M) || defined(__DOXYGEN__)
+
+
+#endif // __XK_ETH_XU316_DUAL_100M_BOARD_H__

--- a/tests/board_support/board_support.cmake
+++ b/tests/board_support/board_support.cmake
@@ -1,0 +1,5 @@
+# Board Support
+
+set(test_board_support_SRCS     ../board_support/src/xk_eth_xu316_dual_100m.xc)
+
+set(test_board_support_INC      ../board_support/api)

--- a/tests/board_support/src/xk_eth_xu316_dual_100m.xc
+++ b/tests/board_support/src/xk_eth_xu316_dual_100m.xc
@@ -1,0 +1,210 @@
+// Copyright 2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include "xk_eth_xu316_dual_100m/board.h"
+#include "test_boards_utils.h"
+#if TEST_BOARD_SUPPORT_BOARD == XK_ETH_XU316_DUAL_100M
+
+#include <xs1.h>
+#include <platform.h>
+
+#define DEBUG_UNIT xk_eth_xu316_dual_100
+#include "debug_print.h"
+#include "xassert.h"
+
+
+// Bit 3 of this port is connected to the PHY resets. Other bits not pinned out.
+on tile[1]: out port p_phy_rst_n = PHY_RST_N;
+on tile[1]: port p_pwrdn_int = PWRDN_INT;
+on tile[1]: out port p_leds = LED_GRN_RED;
+
+#define MMD_GENERAL_RANGE                   0x001F
+
+// Register addresses
+#define IO_CONFIG1_REG                      0x302
+#define LEDCFG_REG                          0x460
+
+// IO configuration register bits (0x302)
+#define IO_CFG1_IMPEDANCE_FAST_MODE_BIT     14
+#define IO_CFG1_CRS_RX_DV_BIT               8
+
+#define ETH_PHY_0_ADDR 0x05
+#define ETH_PHY_1_ADDR 0x07
+static const uint8_t phy_addresses[2] = {ETH_PHY_0_ADDR, ETH_PHY_1_ADDR};
+
+// These drive low for on so set all other bits to high (we use drive_low mode)
+#define LED_OFF 0xffffffff
+#define LED_RED 0xfffffffd
+#define LED_GRN 0xfffffffe
+#define LED_YEL 0xfffffffc
+
+void reset_eth_phys()
+{
+    p_phy_rst_n <: 0x00;
+    delay_microseconds(100); // dp83826e datasheet says 25us min
+    p_phy_rst_n <: 0x08;     // Set bit 3 high
+    delay_milliseconds(2);
+}
+
+rmii_port_timing_t get_port_timings(port_timing_index_t phy_idx){
+    rmii_port_timing_t port_timing = {0};
+    if(phy_idx == DUAL_PHY_MOUNTED_PHY0){
+        port_timing.clk_delay_tx_rising = 1;
+        port_timing.clk_delay_tx_falling = 1;
+        port_timing.clk_delay_rx_rising = 0;
+        port_timing.clk_delay_rx_falling = 0;
+        port_timing.pad_delay_rx = 1;
+    } else if((phy_idx == DUAL_PHY_MOUNTED_PHY1) || (phy_idx == SINGLE_PHY_MOUNTED_PHY0)) {
+        port_timing.clk_delay_tx_rising = 0;
+        port_timing.clk_delay_tx_falling = 0;
+        port_timing.clk_delay_rx_rising = 0;
+        port_timing.clk_delay_rx_falling = 0;
+        port_timing.pad_delay_rx = 4;
+    } else {
+        fail("Invalid PHY idx\n");
+    }
+
+    return port_timing;
+}
+
+
+[[combinable]]
+void dual_dp83826e_phy_driver(CLIENT_INTERFACE(smi_if, i_smi),
+                              NULLABLE_CLIENT_INTERFACE(ethernet_cfg_if, i_eth_phy0),
+                              NULLABLE_CLIENT_INTERFACE(ethernet_cfg_if, i_eth_phy1)){
+
+    // Determine config. We always configure PHY0 because it is clock master.
+    // We may use any combination of at least one PHY.
+    // PHY0 is index 0 and PHY1 is index 1
+    int use_phy0 = !isnull(i_eth_phy0);
+    int use_phy1 = !isnull(i_eth_phy1);
+    int num_phys_to_configure = 0;
+    int num_phys_to_poll = 0;
+    int idx_of_first_phy_to_poll = 0;
+
+    if(use_phy0 && use_phy1){
+        num_phys_to_configure = 2;
+        num_phys_to_poll = 2;
+        idx_of_first_phy_to_poll = 0;
+    }
+    else if (use_phy0 && !use_phy1){
+        num_phys_to_configure = 1;
+        num_phys_to_poll = 1;
+        idx_of_first_phy_to_poll = 0;
+    }
+    else if (!use_phy0 && use_phy1){
+        num_phys_to_configure = 2;
+        num_phys_to_poll = 1;
+        idx_of_first_phy_to_poll = 1;
+    } else {
+        fail("Must specify at least one ethernet_cfg_if configuration interface");
+    }
+
+    set_port_drive_low(p_leds); // So we don't interfere with out lines (eg. xscope)
+    p_leds <: LED_RED;          // Indicate link(s) down
+    p_pwrdn_int :> int _;       // Make Hi Z. This pin is pulled up by the PHY
+
+    reset_eth_phys();
+
+    ethernet_link_state_t link_state[2] = {ETHERNET_LINK_DOWN, ETHERNET_LINK_DOWN};
+    ethernet_speed_t link_speed[2] = {LINK_100_MBPS_FULL_DUPLEX, LINK_100_MBPS_FULL_DUPLEX};
+    const int link_poll_period_ms = 1000;
+
+    // PHY_0 is the clock master so we always configure this one, even if only PHY_1 is used
+    // because PHY_1 is the clock slave and PHY_0 is the clock master
+
+    debug_printf("Starting PHY configuration\n");
+
+    // Setup PHYs. Always configure PHY_0, optionally PHY_1
+    for(int phy_idx = 0; phy_idx < num_phys_to_configure; phy_idx++){
+        uint8_t phy_address = phy_addresses[phy_idx];
+
+        while(smi_phy_is_powered_down(i_smi, phy_address));
+
+        debug_printf("Started PHY %d\n", phy_idx);
+
+        // Set LED config to light the SPEED100M LED correctly. LEDCFG register (0x0460). LED2. Want to set bits 11-8 to 0x5.
+        // Datasheet says LED control is on bits 11-8 but I think it's really bits 4-7.
+        // Reset value seems to be 0x0565, If we write 0x0555 it seems to work.
+        // we should do a read modify write of bits 4-7.
+        // "Here this is a mistake in the datasheet, but please test which led has what registers, to my knowledge the settings described will configure the Leds mentioned."
+        // "Led LED grouping is swapped so LED1 is 3-0 LED2 is 7-4 and LED3 is 11-8 the description status the same. Please confirm with your tests"
+        smi_mmd_write(i_smi, phy_address, MMD_GENERAL_RANGE, LEDCFG_REG, 0x0555);
+
+        // Set pins to higher drive strength "impedance control". This is needed especially for clock signal. This results in a wider eye by some 2ns also.
+        // Note we also ensure RXDV is set too
+        smi_mmd_write(i_smi, phy_address, MMD_GENERAL_RANGE, IO_CONFIG1_REG, (1 << IO_CFG1_IMPEDANCE_FAST_MODE_BIT) | (1 << IO_CFG1_CRS_RX_DV_BIT));
+
+        // Specific setup for PHY_0
+        if(phy_idx == 0){
+            // None
+        }
+
+        // Specific setup for PHY_1 (if used)
+        if(phy_idx == 1){
+            // None
+        }
+    }
+
+
+    // Timer for polling
+    timer tmr;
+    int t;
+    tmr :> t;
+
+    // printf("Number of PHYs to poll: %d\n", num_phys_to_poll);
+    // printf("ID of first PHY to poll: %d\n", idx_of_first_phy_to_poll);
+
+    // Poll link state and update MAC if changed
+    while (1) {
+        select {
+            case tmr when timerafter(t) :> t:
+                for(int phy_idx = idx_of_first_phy_to_poll; phy_idx < idx_of_first_phy_to_poll + num_phys_to_poll; phy_idx++){
+                    uint8_t phy_address = phy_addresses[phy_idx];
+                    ethernet_link_state_t new_state = smi_get_link_state(i_smi, phy_address);
+
+                    if (new_state != link_state[phy_idx]) {
+                        link_state[phy_idx] = new_state;
+                        if(phy_idx == 0){
+                            i_eth_phy0.set_link_state(0, new_state, link_speed[phy_idx]);
+                        } else {
+                            i_eth_phy1.set_link_state(0, new_state, link_speed[phy_idx]);
+                        }
+                    }
+                }
+                // Do LEDs. Red means no link(s). Green means all links up. Yellow means one of two links up (if 2 PHYs uses).
+                if(num_phys_to_poll == 2){
+                    if((link_state[0] == ETHERNET_LINK_UP) && (link_state[1]) == ETHERNET_LINK_UP){ // Both are up
+                        p_leds <: LED_GRN;
+                    } else if((link_state[0] == ETHERNET_LINK_UP) ||(link_state[1]) == ETHERNET_LINK_UP){ // One is up
+                        p_leds <: LED_YEL;
+                    } else {
+                        p_leds <: LED_RED; // Both down
+                    }
+                } else {
+                    if(link_state[idx_of_first_phy_to_poll] == ETHERNET_LINK_UP){
+                        p_leds <: LED_GRN;
+                    } else {
+                        p_leds <: LED_RED;
+                    }
+                }
+                t += link_poll_period_ms * XS1_TIMER_KHZ;
+            break;
+#if ENABLE_MAC_START_NOTIFICATION
+            case use_phy0 => i_eth_phy0.mac_started():
+                // Mac has just started, or restarted
+                i_eth_phy0.ack_mac_start();
+                i_eth_phy0.set_link_state(0, link_state[0], link_speed[0]);
+            break;
+
+            case use_phy1 => i_eth_phy1.mac_started():
+                // Mac has just started, or restarted
+                i_eth_phy1.ack_mac_start();
+                i_eth_phy1.set_link_state(0, link_state[1], link_speed[1]);
+            break;
+#endif
+        }
+    }
+}
+
+#endif // TEST_BOARD_SUPPORT_BOARD == XK_ETH_XU316_DUAL_100M

--- a/tests/board_support/xn_files/xk-eth-xu316-dual-100m.xn
+++ b/tests/board_support/xn_files/xk-eth-xu316-dual-100m.xn
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Network xmlns="http://www.xmos.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.xmos.com http://www.xmos.com" ManuallySpecifiedRouting="true">
+  <Type>Board</Type>
+  <Name>xk_eth_xu316_dual_100m</Name>
+  <Declarations>
+    <Declaration>tileref tile[2]</Declaration>
+  </Declarations>
+  <Packages>
+    <Package id="0" Type="XS3-UnA-1024-TQ128">
+      <Nodes>
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
+          <Boot>
+            <Source Location="bootFlash"/>
+          </Boot>
+          <Tile Number="0" Reference="tile[0]">
+            <!-- QSPI flash -->
+            <Port Location="XS1_PORT_1B"  Name="PORT_SQI_CS"/>
+            <Port Location="XS1_PORT_1C"  Name="PORT_SQI_SCLK"/>
+            <Port Location="XS1_PORT_4B"  Name="PORT_SQI_SIO"/>
+            
+            <!-- PHY 0 Uses upper 2 bits of 4b ports -->
+            <Port Location="XS1_PORT_1A" Name="PHY_0_TX_EN"/>
+            <Port Location="XS1_PORT_4F" Name="PHY_0_TXD_4BIT"/>
+            <Port Location="XS1_PORT_1D" Name="PHY_0_RXDV"/>
+            <Port Location="XS1_PORT_4E" Name="PHY_0_RXD_4BIT"/>
+            <Port Location="XS1_PORT_1K" Name="PHY_0_CLK_50M"/>
+            
+            <!-- PHY 1 Uses 1b ports optionally 8b port for Tx instead of 1b ports-->
+            <Port Location="XS1_PORT_1L" Name="PHY_1_TX_EN"/>
+            <Port Location="XS1_PORT_1I" Name="PHY_1_TXD_0"/>
+            <Port Location="XS1_PORT_1J" Name="PHY_1_TXD_1"/>
+            <Port Location="XS1_PORT_8D" Name="PHY_1_TXD_8BIT"/> 
+            <Port Location="XS1_PORT_1M" Name="PHY_1_RXDV"/>
+            <Port Location="XS1_PORT_1N" Name="PHY_1_RXD_0"/>
+            <Port Location="XS1_PORT_1O" Name="PHY_1_RXD_1"/>
+            <Port Location="XS1_PORT_1P" Name="PHY_1_CLK_50M"/>
+          </Tile>
+          <Tile Number="1" Reference="tile[1]">
+            <!-- Shared config pins for both PHYs -->
+            <Port Location="XS1_PORT_1N"  Name="MDC"/>
+            <Port Location="XS1_PORT_1M"  Name="MDIO"/>
+            
+            <!-- Optional 4b port version MDC on bit 2 MDIO on bit 3 -->
+            <Port Location="XS1_PORT_4F"  Name="MDC_MDIO_4BIT"/>
+            
+            <!-- PHY control ines -->
+            <Port Location="XS1_PORT_4A"  Name="PHY_RST_N"/>
+            <Port Location="XS1_PORT_1O"  Name="PWRDN_INT"/>
+            
+            <!-- Vision board built-in IO -->
+            <Port Location="XS1_PORT_32A" Name="LED_GRN_RED"/>
+            <Port Location="XS1_PORT_1H"  Name="BUTTON"/>
+            <Port Location="XS1_PORT_1L"  Name="PDM_MIC_CLOCK"/>
+            <Port Location="XS1_PORT_1J"  Name="PDM_MIC_DATA"/>
+
+          </Tile>
+        </Node>
+      </Nodes>
+    </Package>
+  </Packages>
+
+  <!-- XTAG4 -->
+  <Nodes>
+    <Node Id="1" Type="device:" RoutingId="0x8000">
+      <Service Id="0" Proto="xscope_host_data(chanend c);">
+        <Chanend Identifier="c" end="3"/>
+      </Service>
+    </Node>
+  </Nodes>
+
+  <!-- XSCOPE LINK -->
+  <Links>
+    <Link Encoding="2wire" Delays="5clk" Flags="XSCOPE">
+      <LinkEndpoint NodeId="0" Link="XL1"/>
+      <LinkEndpoint NodeId="1" Chanend="1"/>
+    </Link>
+  </Links>
+
+  <ExternalDevices>
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="W25Q64JV" PageSize="256" SectorSize="4096" NumPages="32768">
+      <Attribute Name="PORT_SQI_CS"   Value="PORT_SQI_CS"/>
+      <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK"/>
+      <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
+    </Device>
+  </ExternalDevices>
+
+  <JTAGChain>
+    <JTAGDevice NodeId="0"/>
+  </JTAGChain>
+</Network>

--- a/tests/hw_helpers.py
+++ b/tests/hw_helpers.py
@@ -883,7 +883,7 @@ def do_hw_dbg_rx_test(request, testname, mac, arch, packets_to_send):
     else:
         assert False, f"Invalid send_method {send_method}"
 
-    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"loopback_{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         print("Wait for DUT to be ready")
         stdout = xcoreapp.xscope_host.xscope_controller_cmd_connect()

--- a/tests/hw_test_rmii_loopback/CMakeLists.txt
+++ b/tests/hw_test_rmii_loopback/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
-project(hw_test_rmii)
+project(hw_test_rmii_loopback)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../board_support/board_support.cmake)
 
 set(APP_HW_TARGET           xk-eth-xu316-dual-100m.xn)
 
@@ -31,7 +33,7 @@ set(COMPILER_FLAGS_COMMON   -g
                             -Os
                             -Wno-reinterpret-alignment
                             -fxscope
-                            -DBOARD_SUPPORT_BOARD=XK_ETH_XU316_DUAL_100M
+                            -DTEST_BOARD_SUPPORT_BOARD=XK_ETH_XU316_DUAL_100M
                             -DENABLE_MAC_START_NOTIFICATION=1
                             )
 
@@ -47,8 +49,9 @@ file(GLOB COMMON_SOURCES RELATIVE ${CMAKE_CURRENT_LIST_DIR}
                                   "${CMAKE_CURRENT_LIST_DIR}/../hw_test_rmii_rx/src/xscope_control/*.xc")
 
 list(APPEND XC_SOURCES ${COMMON_SOURCES})
-set(APP_XC_SRCS ${XC_SOURCES})
-set(APP_INCLUDES src ../hw_test_rmii_rx/src/xscope_control ../hw_test_rmii_rx/src/xu316_dual_100m_ports ${REL_AUTOGEN_DIR})
+
+set(APP_XC_SRCS ${XC_SOURCES} ${test_board_support_SRCS})
+set(APP_INCLUDES src ../hw_test_rmii_rx/src/xscope_control ../hw_test_rmii_rx/src/xu316_dual_100m_ports ${test_board_support_INC} ${REL_AUTOGEN_DIR})
 
 set(XMOS_SANDBOX_DIR    ${CMAKE_CURRENT_LIST_DIR}/../../..)
 

--- a/tests/hw_test_rmii_loopback/CMakeLists.txt
+++ b/tests/hw_test_rmii_loopback/CMakeLists.txt
@@ -39,7 +39,7 @@ set(COMPILER_FLAGS_COMMON   -g
 
 foreach(phy PHY0 PHY1) # compile for each phy
     string(TOLOWER ${phy} phy_lower)
-    set(APP_COMPILER_FLAGS_loopback_${phy_lower}                ${COMPILER_FLAGS_COMMON} -DETHERNET_SUPPORT_HP_QUEUES=1 -DUSE_${phy}=1)
+    set(APP_COMPILER_FLAGS_${phy_lower}             ${COMPILER_FLAGS_COMMON} -DETHERNET_SUPPORT_HP_QUEUES=1 -DUSE_${phy}=1)
 endforeach()
 
 set(APP_XSCOPE_SRCS ../hw_test_rmii_rx/src/xscope_control/config.xscope)

--- a/tests/hw_test_rmii_rx/CMakeLists.txt
+++ b/tests/hw_test_rmii_rx/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
-project(hw_test_rmii)
+project(hw_test_rmii_rx)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../board_support/board_support.cmake)
 
 set(APP_HW_TARGET           xk-eth-xu316-dual-100m.xn)
 
@@ -31,7 +33,7 @@ set(COMPILER_FLAGS_COMMON   -g
                             -Os
                             -Wno-reinterpret-alignment
                             -fxscope
-                            -DBOARD_SUPPORT_BOARD=XK_ETH_XU316_DUAL_100M
+                            -DTEST_BOARD_SUPPORT_BOARD=XK_ETH_XU316_DUAL_100M
                             -DENABLE_MAC_START_NOTIFICATION=1
                             )
 
@@ -43,7 +45,10 @@ endforeach()
 
 set(APP_XSCOPE_SRCS src/xscope_control/config.xscope)
 
-set(APP_INCLUDES src/xscope_control src/xu316_dual_100m_ports ${REL_AUTOGEN_DIR})
+set(APP_INCLUDES src/xscope_control src/xu316_dual_100m_ports ${test_board_support_INC} ${REL_AUTOGEN_DIR})
+
+file(GLOB_RECURSE XC_SOURCES RELATIVE ${CMAKE_CURRENT_LIST_DIR} "src/*.xc")
+set(APP_XC_SRCS ${XC_SOURCES} ${test_board_support_SRCS})
 
 set(XMOS_SANDBOX_DIR    ${CMAKE_CURRENT_LIST_DIR}/../../..)
 

--- a/tests/hw_test_rmii_rx/CMakeLists.txt
+++ b/tests/hw_test_rmii_rx/CMakeLists.txt
@@ -39,8 +39,8 @@ set(COMPILER_FLAGS_COMMON   -g
 
 foreach(phy PHY0 PHY1) # compile for each phy
     string(TOLOWER ${phy} phy_lower)
-    set(APP_COMPILER_FLAGS_rx_${phy_lower}                 ${COMPILER_FLAGS_COMMON} -DUSE_${phy}=1)
-    set(APP_COMPILER_FLAGS_rx_multiple_queues_${phy_lower}      ${COMPILER_FLAGS_COMMON} -DMULTIPLE_QUEUES=1 -DETHERNET_SUPPORT_HP_QUEUES=1 -DUSE_${phy}=1)
+    set(APP_COMPILER_FLAGS_${phy_lower}                     ${COMPILER_FLAGS_COMMON} -DUSE_${phy}=1)
+    set(APP_COMPILER_FLAGS_multiple_queues_${phy_lower}     ${COMPILER_FLAGS_COMMON} -DMULTIPLE_QUEUES=1 -DETHERNET_SUPPORT_HP_QUEUES=1 -DUSE_${phy}=1)
 endforeach()
 
 set(APP_XSCOPE_SRCS src/xscope_control/config.xscope)

--- a/tests/hw_test_rmii_tx/CMakeLists.txt
+++ b/tests/hw_test_rmii_tx/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
-project(hw_test_rmii)
+project(hw_test_rmii_tx)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../board_support/board_support.cmake)
 
 set(APP_HW_TARGET           xk-eth-xu316-dual-100m.xn)
 
@@ -31,7 +33,7 @@ set(COMPILER_FLAGS_COMMON   -g
                             -Os
                             -Wno-reinterpret-alignment
 							-fxscope
-                            -DBOARD_SUPPORT_BOARD=XK_ETH_XU316_DUAL_100M
+                            -DTEST_BOARD_SUPPORT_BOARD=XK_ETH_XU316_DUAL_100M
                             -DENABLE_MAC_START_NOTIFICATION=1
                             )
 
@@ -50,8 +52,8 @@ file(GLOB COMMON_SOURCES RELATIVE ${CMAKE_CURRENT_LIST_DIR}
 
 list(APPEND XC_SOURCES ${COMMON_SOURCES}  "../include/log_tx_ts.c")
 
-set(APP_XC_SRCS ${XC_SOURCES})
-set(APP_INCLUDES src ../hw_test_rmii_rx/src/xscope_control ../hw_test_rmii_rx/src/xu316_dual_100m_ports ${REL_AUTOGEN_DIR} ../include)
+set(APP_XC_SRCS ${XC_SOURCES} ${test_board_support_SRCS})
+set(APP_INCLUDES src ../hw_test_rmii_rx/src/xscope_control ../hw_test_rmii_rx/src/xu316_dual_100m_ports ${test_board_support_INC} ${REL_AUTOGEN_DIR} ../include)
 
 set(XMOS_SANDBOX_DIR    ${CMAKE_CURRENT_LIST_DIR}/../../..)
 

--- a/tests/hw_test_rmii_tx/CMakeLists.txt
+++ b/tests/hw_test_rmii_tx/CMakeLists.txt
@@ -39,9 +39,9 @@ set(COMPILER_FLAGS_COMMON   -g
 
 foreach(phy PHY0 PHY1) # compile for each phy
     string(TOLOWER ${phy} phy_lower)
-    set(APP_COMPILER_FLAGS_tx_${phy_lower}                             ${COMPILER_FLAGS_COMMON} -DETHERNET_SUPPORT_TRAFFIC_SHAPER=1 -DETHERNET_SUPPORT_HP_QUEUES=1 -DUSE_${phy}=1)
-    set(APP_COMPILER_FLAGS_tx_single_client_${phy_lower}                    ${COMPILER_FLAGS_COMMON} -DSINGLE_CLIENT=1 -DUSE_${phy}=1)
-    set(APP_COMPILER_FLAGS_tx_single_client_with_ts_probe_${phy_lower}     ${COMPILER_FLAGS_COMMON} -DSINGLE_CLIENT=1 -DPROBE_TX_TIMESTAMPS=1 -DUSE_${phy}=1)
+    set(APP_COMPILER_FLAGS_${phy_lower}                                 ${COMPILER_FLAGS_COMMON} -DETHERNET_SUPPORT_TRAFFIC_SHAPER=1 -DETHERNET_SUPPORT_HP_QUEUES=1 -DUSE_${phy}=1)
+    set(APP_COMPILER_FLAGS_single_client_${phy_lower}                   ${COMPILER_FLAGS_COMMON} -DSINGLE_CLIENT=1 -DUSE_${phy}=1)
+    set(APP_COMPILER_FLAGS_single_client_with_ts_probe_${phy_lower}     ${COMPILER_FLAGS_COMMON} -DSINGLE_CLIENT=1 -DPROBE_TX_TIMESTAMPS=1 -DUSE_${phy}=1)
 endforeach()
 
 set(APP_XSCOPE_SRCS ../hw_test_rmii_rx/src/xscope_control/config.xscope)

--- a/tests/test_deps_hw.cmake
+++ b/tests/test_deps_hw.cmake
@@ -1,3 +1,2 @@
 set(APP_DEPENDENT_MODULES   lib_ethernet
-                            "lib_otpinfo(2.2.1)"
-                            "lib_board_support(develop)") # Planning for 1.4.0
+                            "lib_otpinfo(2.2.1)")

--- a/tests/test_hw_4_2_6.py
+++ b/tests/test_hw_4_2_6.py
@@ -38,7 +38,7 @@ def do_test_4_2_6_hw_dbg(request, testname, mac, arch, packets_to_send):
     else:
         assert False, f"Invalid send_method {send_method}"
 
-    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"loopback_{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
 
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         print("Wait for DUT to be ready")

--- a/tests/test_hw_hot_plug.py
+++ b/tests/test_hw_hot_plug.py
@@ -65,7 +65,7 @@ def test_hw_hot_plug(request, seed):
     lp_client_id = 0
     hp_client_id = 1
 
-    xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"tx_{phy}" / f"hw_test_rmii_tx_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"{phy}" / f"hw_test_rmii_tx_{phy}.xe"
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         if dbg.wait_for_links_up():
             print("Links up")

--- a/tests/test_hw_loopback.py
+++ b/tests/test_hw_loopback.py
@@ -88,7 +88,7 @@ def test_hw_loopback(request, send_method):
         assert False, f"Invalid send_method {send_method}"
 
 
-    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"loopback_{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         print("Wait for DUT to be ready")
         if not no_debugger:

--- a/tests/test_hw_restart.py
+++ b/tests/test_hw_restart.py
@@ -59,7 +59,7 @@ def test_hw_restart(request, send_method):
         assert False, f"Invalid send_method {send_method}"
 
 
-    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"loopback_{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_loopback" / "bin" / f"{phy}" / f"hw_test_rmii_loopback_{phy}.xe"
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         print("Wait for DUT to be ready")
         if not no_debugger:

--- a/tests/test_hw_rx_multiple_queues.py
+++ b/tests/test_hw_rx_multiple_queues.py
@@ -70,7 +70,7 @@ def test_hw_rx_multiple_queues(request, send_method, seed):
         assert False, f"Invalid send_method {send_method}"
 
 
-    xe_name = pkg_dir / "hw_test_rmii_rx" / "bin" / f"rx_multiple_queues_{phy}" / f"hw_test_rmii_rx_multiple_queues_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_rx" / "bin" / f"multiple_queues_{phy}" / f"hw_test_rmii_rx_multiple_queues_{phy}.xe"
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         print("Wait for DUT to be ready")
         if not no_debugger:

--- a/tests/test_hw_rx_only.py
+++ b/tests/test_hw_rx_only.py
@@ -105,7 +105,7 @@ def test_hw_rx_only(request, send_method, payload_len, seed):
         assert False, f"Invalid send_method {send_method}"
 
 
-    xe_name = pkg_dir / "hw_test_rmii_rx" / "bin" / f"rx_{phy}" / f"hw_test_rmii_rx_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_rx" / "bin" / f"{phy}" / f"hw_test_rmii_rx_{phy}.xe"
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         print("Wait for DUT to be ready")
 

--- a/tests/test_hw_tx_ifg.py
+++ b/tests/test_hw_tx_ifg.py
@@ -118,9 +118,9 @@ def test_hw_tx_ifg(request, dut_timestamp_probe, packet_type):
     lp_client_id = 0
 
     if not dut_timestamp_probe:
-        xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"tx_single_client_{phy}" / f"hw_test_rmii_tx_single_client_{phy}.xe"
+        xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"single_client_{phy}" / f"hw_test_rmii_tx_single_client_{phy}.xe"
     else:
-        xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"tx_single_client_with_ts_probe_{phy}" / f"hw_test_rmii_tx_single_client_with_ts_probe_{phy}.xe"
+        xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"single_client_with_ts_probe_{phy}" / f"hw_test_rmii_tx_single_client_with_ts_probe_{phy}.xe"
 
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         if dbg.wait_for_links_up():

--- a/tests/test_hw_tx_only.py
+++ b/tests/test_hw_tx_only.py
@@ -84,7 +84,7 @@ def test_hw_tx_only(request, send_method, tx_config):
 
     capture_file = "packets.bin"
 
-    xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"tx_{phy}" / f"hw_test_rmii_tx_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"{phy}" / f"hw_test_rmii_tx_{phy}.xe"
     with XcoreAppControl(adapter_id, xe_name, verbose=verbose) as xcoreapp, hw_eth_debugger() as dbg:
         print("Wait for DUT to be ready")
         stdout = xcoreapp.xscope_host.xscope_controller_cmd_connect()

--- a/tests/test_hw_tx_timer_wrap.py
+++ b/tests/test_hw_tx_timer_wrap.py
@@ -72,7 +72,7 @@ def test_hw_tx_timer_wrap(request, send_method, seed):
 
     host_mac_address = [int(i, 16) for i in host_mac_address_str.split(":")]
     dut_mac_address_lp = [int(i, 16) for i in dut_mac_address_str_lp.split(":")]
-    dut_mac_addres_hp= [int(i, 16) for i in dut_mac_address_str_hp.split(":")]
+    dut_mac_address_hp = [int(i, 16) for i in dut_mac_address_str_hp.split(":")]
 
     xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"{phy}" / f"hw_test_rmii_tx_{phy}.xe"
     print(f"Asking DUT to send the first packet")

--- a/tests/test_hw_tx_timer_wrap.py
+++ b/tests/test_hw_tx_timer_wrap.py
@@ -74,7 +74,7 @@ def test_hw_tx_timer_wrap(request, send_method, seed):
     dut_mac_address_lp = [int(i, 16) for i in dut_mac_address_str_lp.split(":")]
     dut_mac_addres_hp= [int(i, 16) for i in dut_mac_address_str_hp.split(":")]
 
-    xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"tx_{phy}" / f"hw_test_rmii_tx_{phy}.xe"
+    xe_name = pkg_dir / "hw_test_rmii_tx" / "bin" / f"{phy}" / f"hw_test_rmii_tx_{phy}.xe"
     print(f"Asking DUT to send the first packet")
 
     nanoseconds_in_a_second = 1000000000


### PR DESCRIPTION
Updated tests to reference these files,

In updating the tests it was noticed that the hardware test XC projects cmake all had the same project name. Each was updated to match teh folder, this broke the tests due to path building to select specfic XE file. This path building was then fixed in the tests.