### PR TITLE
Adding agent interface config test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,12 +132,12 @@ pipeline {
                     if(params.TEST_TYPE == 'smoke')
                     {
                       echo "Running tests with fixed seed ${env.SEED}"
-                      sh "pytest -v -n auto --junitxml=pytest_result.xml --seed ${env.SEED} -k 'not hw and not tx_ifg' "
+                      runPytest("-v -n=auto --seed ${env.SEED} -k 'not hw and not tx_ifg and not pc' ")
                     }
                     else
                     {
                       echo "Running tests with random seed"
-                      sh "pytest -v -n auto --junitxml=pytest_result.xml -k 'not hw' "
+                      runPytest("-v -n=auto --seed ${env.SEED} -k 'not hw and not pc' ")
                     }
                   } // script
                 } // withTools
@@ -146,7 +146,6 @@ pipeline {
           } // steps
           post {
             always {
-              junit "${REPO_NAME}/tests/pytest_result.xml"
               archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_*.txt", fingerprint: true, allowEmptyArchive: true
             }
             cleanup {
@@ -175,7 +174,7 @@ pipeline {
                       // Use withEnv to pass the variable to the shell
                       withEnv(["HW_TEST_DURATION=${hwTestDuration}"]) {
                         withXTAG(["xk-eth-xu316-dual-100m"]) { xtagIds ->
-                          sh "pytest -v --junitxml=pytest_result.xml --adapter-id ${xtagIds[0]} --eth-intf eno1 --test-duration ${env.HW_TEST_DURATION} --phy phy0 -k 'hw' --timeout=600 --session-timeout=3600"
+                          runPytest("-v -n=1 --adapter-id ${xtagIds[0]} --eth-intf eno1 --test-duration ${env.HW_TEST_DURATION} --phy phy0 -k 'hw or pc' --timeout=600 --session-timeout=3600")
                         } // withXTAG
                       } // withEnv(["HW_TEST_DURATION=${hwTestDuration}"])
                   } // script
@@ -185,7 +184,6 @@ pipeline {
           } // steps
           post {
             always {
-              junit "${REPO_NAME}/tests/pytest_result.xml"
               archiveArtifacts artifacts: "${REPO_NAME}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
               archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
             }
@@ -216,7 +214,7 @@ pipeline {
                       // Use withEnv to pass the variable to the shell
                       withEnv(["HW_TEST_DURATION=${hwTestDuration}"]) {
                         withXTAG(["xk-eth-xu316-dual-100m"]) { xtagIds ->
-                          sh "pytest -v --junitxml=pytest_result.xml --adapter-id ${xtagIds[0]} --eth-intf enp110s0 --test-duration ${env.HW_TEST_DURATION} --phy phy1 -k 'hw' --timeout=600 --session-timeout=3600"
+                          runPytest("-v -n=1 --adapter-id ${xtagIds[0]} --eth-intf enp110s0 --test-duration ${env.HW_TEST_DURATION} --phy phy1 -k 'hw or pc' --timeout=600 --session-timeout=3600")
                         } // withXTAG
                       } // withEnv(["HW_TEST_DURATION=${hwTestDuration}"])
                   } // script
@@ -226,7 +224,6 @@ pipeline {
           } // steps
           post {
             always {
-              junit "${REPO_NAME}/tests/pytest_result.xml"
               archiveArtifacts artifacts: "${REPO_NAME}/tests/*_fail.pcapng", fingerprint: true, allowEmptyArchive: true
               archiveArtifacts artifacts: "${REPO_NAME}/tests/ifg_sweep_*.txt", fingerprint: true, allowEmptyArchive: true
             }

--- a/tests/test_pc_if.py
+++ b/tests/test_pc_if.py
@@ -15,19 +15,16 @@ def test_pc_if(request):
 
     intf = request.config.getoption("--eth-intf")
 
-    ip_cmd = ["ip", "a", "|", "grep"]
-    ip_cmd.append(intf)
-
-    ip_cmd_str = ' '.join(ip_cmd)
     # Append ':' to the interface name to avoid duplicate matches, as it expects something similar to,
     # "3: eno1: <BROADCAST,MULTICAST,UP,LOWER_UP> ..."
-    ip_cmd_str += ":"
+    ip_cmd_str = f"ip a | grep {intf}:"
 
     result = subprocess.run(ip_cmd_str, shell=True, capture_output=True)
+    
     ip_string = result.stdout.decode('utf-8').strip()
 
     # Check that the command was successful
-    assert result.returncode == 0, "Command failed to return a line"
+    assert result.returncode == 0, "Grep command failed to return a line"
 
     # Is interface UP?
     assert "UP" in ip_string

--- a/tests/test_pc_if.py
+++ b/tests/test_pc_if.py
@@ -1,0 +1,37 @@
+# Copyright 2025 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
+import pytest
+import subprocess
+
+
+def test_pc_if(request):
+    """
+    This tests the agent running the tests to check that the interface settings are correct.
+
+    Using subprocess to run 'ip a | grep <phy>:' to get the interface details and check that
+    1. The interface is UP
+    2. The interface is using pfifo_fast qdisc
+    """
+
+    intf = request.config.getoption("--eth-intf")
+
+    ip_cmd = ["ip", "a", "|", "grep"]
+    ip_cmd.append(intf)
+
+    ip_cmd_str = ' '.join(ip_cmd)
+    # Append ':' to the interface name to avoid duplicate matches, as it expects something similar to,
+    # "3: eno1: <BROADCAST,MULTICAST,UP,LOWER_UP> ..."
+    ip_cmd_str += ":"
+
+    result = subprocess.run(ip_cmd_str, shell=True, capture_output=True)
+    ip_string = result.stdout.decode('utf-8').strip()
+
+    # Check that the command was successful
+    assert result.returncode == 0, "Command failed to return a line"
+
+    # Is interface UP?
+    assert "UP" in ip_string
+
+    # Is interface using pfifo_fast qdisc?
+    assert "qdisc" in ip_string
+    assert "qdisc pfifo_fast" in ip_string


### PR DESCRIPTION
On a reboot (or reset) the agents can lose some of their config especailly around qdisc, which then causes many tests to fail.
Write up here, https://xmosjira.atlassian.net/wiki/spaces/Ethernet/pages/4539088900/Ethernet+Hardware+Test+Agent+Setup