### PR TITLE
Run PC qdisc interface config test first

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,6 +27,7 @@ scapy==2.6.1
 numpy==2.2.3
 python-pcapng==2.1.1
 pytest-timeout==2.3.1
+pytest-order==1.3.0
 
 # Development dependencies
 #

--- a/tests/test_pc_if.py
+++ b/tests/test_pc_if.py
@@ -4,6 +4,7 @@ import pytest
 import subprocess
 
 
+@pytest.mark.order(1)
 def test_pc_if(request):
     """
     This tests the agent running the tests to check that the interface settings are correct.


### PR DESCRIPTION
Failure of this test will highlight the cause of other test failures.